### PR TITLE
Improve performance of pept2filtered

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -273,11 +273,11 @@ class Api::ApiController < ApplicationController
   private
 
   # log all api calls to stathat
-  def log
-    return unless Rails.application.config.unipept_API_logging
-
-    StatHat::API.ez_post_count("API - #{action_name}", Rails.application.config.unipept_stathat_key, 1)
-  end
+  # def log
+  #   return unless Rails.application.config.unipept_API_logging
+  #
+  #   StatHat::API.ez_post_count("API - #{action_name}", Rails.application.config.unipept_stathat_key, 1)
+  # end
 
   # enable cross origin requests
   def set_headers

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -8,7 +8,7 @@ class Api::ApiController < ApplicationController
   before_action :set_query, only: %i[pept2taxa pept2lca peptinfo taxonomy]
   before_action :set_sequences, only: %i[pept2prot]
 
-  before_action :log, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree]
+  # before_action :log, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree]
 
   # sends a message to the ruby cli
   def messages

--- a/app/controllers/mpa_controller.rb
+++ b/app/controllers/mpa_controller.rb
@@ -31,14 +31,32 @@ class MpaController < HandleOptionsController
 
     @equate_il = params[:equate_il].nil? ? true : params[:equate_il]
 
-    @sequences = Sequence
-                 .joins(peptides: [:uniprot_entry])
-                 .includes(peptides: [:uniprot_entry])
-                 .where(sequence: peptides)
-                 .where(uniprot_entry: { taxon_id: taxa_filter_ids })
-                 .uniq
+    @seq_entries = {}
+    uniprot_ids = []
 
-    uniprot_ids = @sequences.map { |s| s.peptides.map(&:uniprot_entry_id) }.flatten.uniq
+    taxa_filter_ids.each_slice(5000) do |taxa_slice|
+      sequence_subset = Sequence
+                        .joins(peptides: [:uniprot_entry])
+                        .includes(peptides: [:uniprot_entry])
+                        .where(sequence: peptides)
+                        .where(uniprot_entry: { taxon_id: taxa_slice })
+                        .uniq
+
+      sequence_subset.each do |seq_info|
+        @seq_entries[seq_info.sequence] = [] unless @seq_entries.key?(seq_info.sequence)
+
+        @seq_entries[seq_info.sequence] += seq_info
+                                           .peptides
+                                           .map(&:uniprot_entry)
+                                           .select { |e| taxa_filter_ids.include? e.taxon_id }
+
+        @seq_entries[seq_info.sequence].uniq!
+      end
+
+      uniprot_ids += sequence_subset.map { |s| s.peptides.map(&:uniprot_entry_id) }.flatten.uniq
+    end
+
+    uniprot_ids = uniprot_ids.uniq
 
     @go_terms = GoCrossReference
                 .where(uniprot_entry_id: uniprot_ids)
@@ -48,8 +66,6 @@ class MpaController < HandleOptionsController
 
     @ipr_entries = InterproCrossReference
                    .where(uniprot_entry_id: uniprot_ids)
-
-    @seq_entries = @sequences.map { |s| [s, s.peptides.map(&:uniprot_entry).select { |e| taxa_filter_ids.include? e.taxon_id }] }
   end
 
   private

--- a/app/views/mpa/pept2filtered.json.jbuilder
+++ b/app/views/mpa/pept2filtered.json.jbuilder
@@ -1,9 +1,25 @@
-json.peptides @seq_entries do |seq_entry|
-  json.sequence seq_entry[0].sequence
-  json.taxa seq_entry[1].map(&:taxon_id).uniq
+json.peptides @seq_entries.each do |sequence, uniprot_entries|
+  json.sequence sequence
+  json.taxa uniprot_entries.map(&:taxon_id).uniq
   json.fa do
-    json.go_terms @go_terms.map(&:go_term_code).uniq
-    json.ec_numbers(@ec_numbers.map(&:ec_number_code).reject(&:empty?).uniq.map { |ec| "EC:#{ec}" })
-    json.interpro_entries(@ipr_entries.map(&:interpro_entry_code).uniq.map { |ipr| ipr.sub('IPR', 'IPR:') })
+    json.go_terms(@go_terms
+                  .select { |go| uniprot_entries.map(&:id).include? go.uniprot_entry_id }
+                  .map(&:go_term_code)
+                  .reject(&:empty?)
+                  .uniq)
+
+    json.ec_numbers(@ec_numbers
+                    .select { |ec| uniprot_entries.map(&:id).include? ec.uniprot_entry_id }
+                    .map(&:ec_number_code)
+                    .reject(&:empty?)
+                    .uniq
+                    .map { |ec| "EC:#{ec}" })
+
+    json.interpro_entries(@ipr_entries
+                          .select { |ipr| uniprot_entries.map(&:id).include? ipr.uniprot_entry_id }
+                          .map(&:interpro_entry_code)
+                          .reject(&:empty?)
+                          .uniq
+                          .map { |ipr| ipr.sub('IPR', 'IPR:') })
   end
 end

--- a/app/views/private_api/ecnumbers.json.jbuilder
+++ b/app/views/private_api/ecnumbers.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @ecnumbers do |ecnumber|
+  json.code ecnumber.code
+  json.name ecnumber.name
+end

--- a/app/views/private_api/error.json.jbuilder
+++ b/app/views/private_api/error.json.jbuilder
@@ -1,0 +1,2 @@
+json.name @error_name
+json.message @error_message

--- a/app/views/private_api/goterms.json.jbuilder
+++ b/app/views/private_api/goterms.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @goterms do |goterm|
+  json.code goterm.code
+  json.name goterm.name
+  json.namespace goterm.namespace
+end

--- a/app/views/private_api/interpros.json.jbuilder
+++ b/app/views/private_api/interpros.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @interpros do |interpro|
+  json.code interpro.code
+  json.category interpro.category
+  json.name interpro.name
+end

--- a/app/views/private_api/metadata.json.jbuilder
+++ b/app/views/private_api/metadata.json.jbuilder
@@ -1,0 +1,1 @@
+json.db_version @data[:db_version]

--- a/app/views/private_api/proteins.json.jbuilder
+++ b/app/views/private_api/proteins.json.jbuilder
@@ -1,0 +1,10 @@
+json.lca @lca_taxon ? @lca_taxon.id : -1
+json.common_lineage(@common_lineage.map(&:id))
+json.proteins @entries do |entry|
+  json.uniprotAccessionId entry.uniprot_accession_number
+  json.name entry.name
+  json.organism entry.taxon_id
+  json.ecNumbers(entry.ec_cross_references.map(&:ec_number_code))
+  json.goTerms(entry.go_cross_references.map(&:go_term_code))
+  json.interproEntries(entry.interpro_cross_references.map(&:interpro_entry_code))
+end

--- a/app/views/private_api/taxa.json.jbuilder
+++ b/app/views/private_api/taxa.json.jbuilder
@@ -1,0 +1,6 @@
+json.array! @taxa do |taxon|
+  json.id taxon.id
+  json.name taxon.name
+  json.rank taxon.rank
+  json.lineage(Lineage.ranks.map { |rank| taxon.lineage.send(rank) })
+end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server


### PR DESCRIPTION
This PR improves the performance of the pept2filtered endpoint (and should help to overcome OutOfMemory exceptions occurring on our production server).

The PR also fixes an issue where the same set of functional annotations was always reported for each peptide sequence.