### PR TITLE
Keep track of original I's when equating I and L

### DIFF
--- a/app/controllers/mpa_controller.rb
+++ b/app/controllers/mpa_controller.rb
@@ -7,9 +7,13 @@ class MpaController < HandleOptionsController
     peptides = params[:peptides] || []
     missed = params[:missed] || false
     @equate_il = params[:equate_il].nil? ? true : params[:equate_il]
+
+    # If equate_il is set, we have to replace all I's by and L in the input peptides.
+    equalized_pepts = peptides.map { |p| p.gsub('I', 'L') } if @equate_il
+
     @peptides = Sequence
                 .includes(Sequence.lca_t_relation_name(@equate_il) => :lineage)
-                .where(sequence: peptides)
+                .where(sequence: equalized_pepts)
                 .where.not(Sequence.lca_t_relation_name(@equate_il) => nil)
     if missed
       @peptides += peptides
@@ -18,9 +22,23 @@ class MpaController < HandleOptionsController
                    .compact
     end
 
-    @results_fa = {}
+    eq_seq_to_fa = {}
+    eq_seq_to_info = {}
+
     @peptides.each do |sequence|
-      @results_fa[sequence.sequence] = sequence.calculate_fa(@equate_il)
+      eq_seq_to_fa[sequence.sequence] = sequence.calculate_fa(@equate_il)
+      eq_seq_to_info[sequence.sequence] = sequence
+    end
+
+    @original_pep_results = {}
+    @original_pep_fas = {}
+
+    peptides.each do |original_seq|
+      equalized_seq = original_seq.gsub('I', 'L')
+      if eq_seq_to_info.key? equalized_seq
+        @original_pep_results[original_seq] = eq_seq_to_info[equalized_seq]
+        @original_pep_fas[original_seq] = eq_seq_to_fa[equalized_seq]
+      end
     end
   end
 

--- a/app/views/mpa/pept2data.json.jbuilder
+++ b/app/views/mpa/pept2data.json.jbuilder
@@ -1,10 +1,10 @@
-json.peptides @peptides do |peptide|
-  json.sequence peptide.sequence
+json.peptides @original_pep_results do |orig_seq, peptide|
+  json.sequence orig_seq
   json.lca @equate_il ? peptide.lca_il : peptide.lca
   l = peptide.send(Sequence.lca_t_relation_name(@equate_il)).lineage
   json.lineage(Lineage.ranks.map { |rank| l.send(rank) })
   json.fa do
-    json.counts @results_fa[peptide.sequence]['num']
-    json.data @results_fa[peptide.sequence]['data']
+    json.counts @original_pep_fas[orig_seq]['num']
+    json.data @original_pep_fas[orig_seq]['data']
   end
 end


### PR DESCRIPTION
This PR changes the way that the equation of I's and L's are handled by the API when `equate_il` is set to `true`. Before, the input peptides weren't allowed to contain `I`'s and the API relied on the client-side to perform the substitution of these amino acids.

Now, this substitution should no longer be done by client-side applications, but is rather handled by the API itself (which also makes it possible to still distinguish between I and L when exporting files with the Unipept web application). This PR thus provides a fix for the following two issues: https://github.com/unipept/unipept/issues/639 and https://github.com/unipept/unipept/issues/1547.