### PR TITLE
Fetch taxonomic and functional information for UniProt id's

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,8 +3,8 @@ require 'octokit'
 class Api::ApiController < ApplicationController
   respond_to :json
 
-  before_action :set_headers, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree]
-  before_action :set_params, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree]
+  before_action :set_headers, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree protinfo]
+  before_action :set_params, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree protinfo]
   before_action :set_query, only: %i[pept2taxa pept2lca peptinfo taxonomy]
   before_action :set_sequences, only: %i[pept2prot]
 
@@ -267,6 +267,28 @@ class Api::ApiController < ApplicationController
     @result = @result.index_by(&:id)
     @input_order = @input.select { |i| @result.key? i.to_i }
     @result = @input_order.map { |i| @result[i.to_i] }
+    respond_with(@result)
+  end
+
+  # Returns the taxonomic and functional information for given uniprot id's
+  # param[input]: Array, required, List of input uniprot id's
+  def protinfo
+    @result = {}
+
+    UniprotEntry
+      .includes(:taxon, :ec_numbers, :go_terms, :interpro_entries)
+      .where(uniprot_accession_number: @input_order)
+      .find_in_batches do |batch|
+        batch.each do |uniprot_id|
+          @result[uniprot_id.uniprot_accession_number] = {
+            taxon: uniprot_id.taxon,
+            ec: uniprot_id.ec_numbers.map(&:code),
+            go: uniprot_id.go_terms.map(&:code),
+            interpro: uniprot_id.interpro_entries.map(&:code)
+          }
+        end
+      end
+
     respond_with(@result)
   end
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -282,9 +282,9 @@ class Api::ApiController < ApplicationController
         batch.each do |uniprot_id|
           @result[uniprot_id.uniprot_accession_number] = {
             taxon: uniprot_id.taxon,
-            ec: uniprot_id.ec_numbers.map(&:code),
-            go: uniprot_id.go_terms.map(&:code),
-            interpro: uniprot_id.interpro_entries.map(&:code)
+            ec: uniprot_id.ec_numbers.map { |ec| { ec_number: ec.code } },
+            go: uniprot_id.go_terms.map { |go| { go_term: go.code } },
+            interpro: uniprot_id.interpro_entries.map { |interpro| { code: interpro.code } }
           }
         end
       end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -284,7 +284,7 @@ class Api::ApiController < ApplicationController
             taxon: uniprot_id.taxon,
             ec: uniprot_id.ec_numbers.map { |ec| { ec_number: ec.code } },
             go: uniprot_id.go_terms.map { |go| { go_term: go.code } },
-            interpro: uniprot_id.interpro_entries.map { |interpro| { code: interpro.code } }
+            ipr: uniprot_id.interpro_entries.map { |interpro| { code: interpro.code } }
           }
         end
       end

--- a/app/views/api/api/protinfo.json.jbuilder
+++ b/app/views/api/api/protinfo.json.jbuilder
@@ -1,0 +1,13 @@
+json.array! @input_order do |uniprot_id|
+  if @result.key? uniprot_id
+      json.protein uniprot_id
+
+      json.ec @result[uniprot_id][:ec]
+      json.go @result[uniprot_id][:go]
+      json.interpro @result[uniprot_id][:interpro]
+
+      json.taxon_id @result[uniprot_id][:taxon][:id]
+      json.taxon_name @result[uniprot_id][:taxon][:name]
+      json.taxon_rank @result[uniprot_id][:taxon][:rank]
+  end
+end

--- a/app/views/api/api/protinfo.json.jbuilder
+++ b/app/views/api/api/protinfo.json.jbuilder
@@ -4,7 +4,7 @@ json.array! @input_order do |uniprot_id|
 
     json.ec @result[uniprot_id][:ec]
     json.go @result[uniprot_id][:go]
-    json.interpro @result[uniprot_id][:interpro]
+    json.ipr @result[uniprot_id][:ipr]
 
     json.taxon_id @result[uniprot_id][:taxon][:id]
     json.taxon_name @result[uniprot_id][:taxon][:name]

--- a/app/views/api/api/protinfo.json.jbuilder
+++ b/app/views/api/api/protinfo.json.jbuilder
@@ -1,13 +1,13 @@
 json.array! @input_order do |uniprot_id|
   if @result.key? uniprot_id
-      json.protein uniprot_id
+    json.protein uniprot_id
 
-      json.ec @result[uniprot_id][:ec]
-      json.go @result[uniprot_id][:go]
-      json.interpro @result[uniprot_id][:interpro]
+    json.ec @result[uniprot_id][:ec]
+    json.go @result[uniprot_id][:go]
+    json.interpro @result[uniprot_id][:interpro]
 
-      json.taxon_id @result[uniprot_id][:taxon][:id]
-      json.taxon_name @result[uniprot_id][:taxon][:name]
-      json.taxon_rank @result[uniprot_id][:taxon][:rank]
+    json.taxon_id @result[uniprot_id][:taxon][:id]
+    json.taxon_name @result[uniprot_id][:taxon][:name]
+    json.taxon_rank @result[uniprot_id][:taxon][:rank]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     match 'peptinfo' => 'api#peptinfo', via: %i[get post]
     match 'taxonomy' => 'api#taxonomy', via: %i[get post]
     match 'messages' => 'api#messages', via: %i[get post]
+    match 'protinfo' => 'api#protinfo', via: %i[get post]
   end
 
   namespace :api, path: 'api/v2' do
@@ -49,5 +50,6 @@ Rails.application.routes.draw do
     match 'peptinfo' => 'api#peptinfo', via: %i[get post]
     match 'taxonomy' => 'api#taxonomy', via: %i[get post]
     match 'messages' => 'api#messages', via: %i[get post]
+    match 'protinfo' => 'api#protinfo', via: %i[get post]
   end
 end


### PR DESCRIPTION
Endpoint that enables a user to fetch the taxonomic and functional information, given a list of UniProt identifiers.

A different tool (PathwayPilot) wants to retrieve taxonomic and functional information for both peptides and UniProt id's. Unipept already provides and endpoint for peptides (**peptinfo**), but not for proteins. 

Since Unipept already stores an index over de UniProt accession id's, we can easily add a **protinfo** endpoint that contains the same information and format as its peptide counterpart. The added benefits over other endpoints are:
* An identical format as the **peptinfo** endpoint. This allows end users to work with the same data, independently from
the input.
* Batch requests. This endpoint can process multiple UniProt id's fast, while other resources are limited and thus slower.