### PR TITLE
Add cutoff parameter to pept2filtered

### DIFF
--- a/app/controllers/mpa_controller.rb
+++ b/app/controllers/mpa_controller.rb
@@ -54,11 +54,11 @@ class MpaController < HandleOptionsController
     uniprot_ids = []
 
     peptides_under_cutoff = Sequence
-      .joins(:peptides)
-      .where(sequence: peptides)
-      .group('sequences.id')
-      .having('count(peptides.id) < ?', cutoff)
-      .pluck(:sequence)
+                            .joins(:peptides)
+                            .where(sequence: peptides)
+                            .group('sequences.id')
+                            .having('count(peptides.id) < ?', cutoff)
+                            .pluck(:sequence)
 
     taxa_filter_ids.each_slice(5000) do |taxa_slice|
       sequence_subset = Sequence

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,16 +13,16 @@ module UnipeptApi
     config.load_defaults 7.0
 
     config.versions = {
-      unipept: '4.6.4',
-      gem: '2.2.1',
-      uniprot: '2021.03',
-      desktop: '1.2.4'
+      unipept: '5.0.9',
+      gem: '3.0.2',
+      uniprot: '2023.03',
+      desktop: '2.0.0'
     }
-    
+
     config.api_only = true
 
     config.api_host = 'api.unipept.ugent.be'
-    
+
     MultiJson.use :Oj
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: mysql2
-  username: unipept
+  username: root
   password: unipept
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,7 @@ default: &default
 
 development:
   <<: *default
+  username: unipept
   database: unipept
   # setup local port forwarding for this to work
   host: 127.0.0.1

--- a/config/deploy/feat.rb
+++ b/config/deploy/feat.rb
@@ -2,12 +2,16 @@ set :stage, :dev
 
 set :deploy_to, '/home/unipept/rails'
 
+set :server, ENV['server'] || 'rick.ugent.be'
+
+#set :rvm_custom_path, '/usr/share/rvm'
+
 # don't specify db as it's not needed for unipept
-server 'sherlock.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
+server "#{fetch(:server)}", user: 'unipept', roles: %i[web app], ssh_options: {
   port: 4840
 }
 
-set :branch, 'feature/pept2filtered'
+set :branch, 'feature/pept2filtered-cutoff'
 set :rails_env, :development
 
 namespace :deploy do
@@ -22,4 +26,6 @@ namespace :deploy do
       upload! StringIO.new(content), "#{release_path}/public/robots.txt"
     end
   end
+
 end
+

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,7 +4,7 @@ set :deploy_to, '/home/unipept/rails'
 
 set :server, ENV['server'] || 'patty.ugent.be'
 
-set :rvm_custom_path, '/usr/share/rvm'
+#set :rvm_custom_path, '/usr/share/rvm'
 
 # don't specify db as it's not needed for unipept
 server "#{fetch(:server)}", user: 'unipept', roles: %i[web app], ssh_options: {

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,6 +4,8 @@ set :deploy_to, '/home/unipept/rails'
 
 set :server, ENV['server'] || 'patty.ugent.be'
 
+set :rvm_custom_path, '/usr/share/rvm'
+
 # don't specify db as it's not needed for unipept
 server "#{fetch(:server)}", user: 'unipept', roles: %i[web app], ssh_options: {
   port: 4840

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,8 +2,10 @@ set :stage, :prod
 
 set :deploy_to, '/home/unipept/rails'
 
+set :server, ENV['server'] || 'patty.ugent.be'
+
 # don't specify db as it's not needed for unipept
-server 'rick.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
+server "#{fetch(:server)}", user: 'unipept', roles: %i[web app], ssh_options: {
   port: 4840
 }
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,8 +53,9 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
 
   # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  # config.active_record.verbose_query_logs = true
 
+  # config.log_level = :info
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,9 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Do not log SQL queries in production mode (this can cause the server to go out of disk space).
+  config.log_level = :info
+
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")


### PR DESCRIPTION
This PR adds a new `cutoff` parameter to the `pept2filtered` endpoint that allows users to instruct Unipept only to consider peptides that are relatively unique (i.e. are present in less than `n` proteins, where `n` is the cutoff). This can also help to drastically speed up the `pept2filtered` endpoint.