### PR TITLE
Limit Rails log files to 500MiB in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,7 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
+  config.logger = ActiveSupport::Logger.new(config.paths["log"].first, 1, 500 * 1024 * 1024) # 50 MB
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
This PR adds a new setting to the rails config in production such that log files will not grow above 500MiB in size.