### PR TITLE
Properly handle options request for /api endpoints

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,6 +1,6 @@
 require 'octokit'
 
-class Api::ApiController < ApplicationController
+class Api::ApiController < HandleOptionsController
   respond_to :json
 
   before_action :set_headers, only: %i[pept2taxa pept2lca pept2prot pept2funct pept2ec pept2go pept2interpro peptinfo taxa2lca taxonomy taxa2tree protinfo]

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,3 +1,5 @@
+# Example: cap dev deploy server=patty.taild1497.ts.net
+
 set :stage, :dev
 
 set :deploy_to, '/home/unipept/rails'

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -2,12 +2,14 @@ set :stage, :dev
 
 set :deploy_to, '/home/unipept/rails'
 
+set :server, ENV['server'] || 'patty.ugent.be'
+
 # don't specify db as it's not needed for unipept
-server 'sherlock.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
+server "#{fetch(:server)}", user: 'unipept', roles: %i[web app], ssh_options: {
   port: 4840
 }
 
-set :branch, 'feature/pept2filtered'
+set :branch, 'fix/options_request_api'
 set :rails_env, :development
 
 namespace :deploy do

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,3 +1,5 @@
+# Example: cap prod deploy server=patty.taild1497.ts.net
+
 set :stage, :prod
 
 set :deploy_to, '/home/unipept/rails'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  # General inforamtion
+  # General information
   scope :private_api, as: 'private_api' do
     match "/*path", via: [:options], :to => "handle_options#handle_options_request"
     match "goterms", via: [:get, :post], :to => "private_api#goterms"
@@ -20,8 +20,11 @@ Rails.application.routes.draw do
     match 'sampledata', via: [:post], to: 'datasets#sampledata'
   end
 
-  namespace :api, path: 'api/v1' do
+  scope :api, as: 'api' do
     match '/*path', via: [:options], to: 'handle_options#handle_options_request'
+  end
+
+  namespace :api, path: 'api/v1' do
     match 'pept2taxa' => "api#pept2taxa", via: %i[get post]
     match 'pept2lca' => "api#pept2lca", via: %i[get post]
     match 'taxa2lca' => 'api#taxa2lca', via: %i[get post]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,6 @@ Rails.application.routes.draw do
   end
 
   namespace :api, path: 'api/v2' do
-    match '/*path', via: [:options], to: 'handle_options#handle_options_request'
     match 'pept2taxa' => "api#pept2taxa", via: %i[get post]
     match 'pept2lca' => "api#pept2lca", via: %i[get post]
     match 'taxa2lca' => 'api#taxa2lca', via: %i[get post]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api, path: 'api/v1' do
+    match '/*path', via: [:options], to: 'handle_options#handle_options_request'
     match 'pept2taxa' => "api#pept2taxa", via: %i[get post]
     match 'pept2lca' => "api#pept2lca", via: %i[get post]
     match 'taxa2lca' => 'api#taxa2lca', via: %i[get post]
@@ -37,6 +38,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api, path: 'api/v2' do
+    match '/*path', via: [:options], to: 'handle_options#handle_options_request'
     match 'pept2taxa' => "api#pept2taxa", via: %i[get post]
     match 'pept2lca' => "api#pept2lca", via: %i[get post]
     match 'taxa2lca' => 'api#taxa2lca', via: %i[get post]


### PR DESCRIPTION
Modern browsers typically first perform an OPTIONS request before effectively performing a GET or POST request. This OPTIONS request wasn't properly handled by the `/api/*` endpoints of the Unipept API. This PR provides a fix for this issue by properly listening and responding to OPTIONS requests.