### PR TITLE
Increate key space limit to 10MiB

### DIFF
--- a/config/initializers/rack_initializer.rb
+++ b/config/initializers/rack_initializer.rb
@@ -1,0 +1,4 @@
+if Rack::Utils.respond_to?("key_space_limit=")
+  # Increase limit to 10 MiB
+  Rack::Utils.key_space_limit = 10485760
+end


### PR DESCRIPTION
This PR increases the default key space limit of Rails to 10MiB. This parameter was set too low by default, causing benign requests to fail.