### PR TITLE
Fix/cli newlines

### DIFF
--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -34,6 +35,10 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra }: Parameters
 ) -> Result<Vec<EcInformation>, ()> {
+    eprintln!("{:?}", input);
+    let input = sanitize_peptides(input);
+    eprintln!("{:?}", input);
+
     let result = index.analyse(&input, equate_il);
 
     let ec_store = datastore.ec_store();

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -35,9 +35,7 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra }: Parameters
 ) -> Result<Vec<EcInformation>, ()> {
-    eprintln!("{:?}", input);
     let input = sanitize_peptides(input);
-    eprintln!("{:?}", input);
 
     let result = index.analyse(&input, equate_il);
 

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -40,6 +41,8 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<FunctInformation>, ()> {
+    let input = sanitize_peptides(input);
+
     let result = index.analyse(&input, equate_il);
 
     let ec_store = datastore.ec_store();

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -36,6 +37,8 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<GoInformation>, ()> {
+    let input = sanitize_peptides(input);
+
     let result = index.analyse(&input, equate_il);
 
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -36,6 +37,8 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<InterproInformation>, ()> {
+    let input = sanitize_peptides(input);
+
     let result = index.analyse(&input, equate_il);
 
     let interpro_store = datastore.interpro_store();

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -49,6 +50,8 @@ async fn handler(
     Parameters { input, equate_il, extra, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<LcaInformation>, ()> {
+    let input = sanitize_peptides(input);
+
     let result = index.analyse(&input, equate_il);
 
     let taxon_store = datastore.taxon_store();

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -10,6 +10,7 @@ use crate::{
     errors::ApiError,
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -48,6 +49,8 @@ async fn handler(
     State(AppState { index, datastore, database }): State<AppState>,
     Parameters { input, equate_il, extra }: Parameters
 ) -> Result<Vec<ProtInformation>, ApiError> {
+    let input = sanitize_peptides(input);
+
     let connection = database.get_conn().await?;
 
     let result = index.analyse(&input, equate_il);

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -48,6 +49,8 @@ async fn handler(
     Parameters { input, equate_il, extra, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<TaxaInformation>, ()> {
+    let input = sanitize_peptides(input);
+
     let result = index.analyse(&input, equate_il);
 
     let taxon_store = datastore.taxon_store();

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -59,6 +60,8 @@ async fn handler(
     Parameters { input, equate_il, extra, domains, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<PeptInformation>, ()> {
+    let input = sanitize_peptides(input);
+
     let result = index.analyse(&input, equate_il);
 
     let ec_store = datastore.ec_store();

--- a/api/src/controllers/api/protinfo.rs
+++ b/api/src/controllers/api/protinfo.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_proteins;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -56,6 +57,8 @@ async fn handler(
     Parameters { input, extra, domains, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<ProtInformation>, ApiError> {
+    let input = sanitize_proteins(input);
+
     let connection = database.get_conn().await?;
 
     let entries = connection.interact(move |conn| get_accessions(conn, &input)).await??;

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -42,6 +43,8 @@ async fn handler(
 
     peptides.sort();
     peptides.dedup();
+    let peptides = sanitize_peptides(peptides);
+
     let result = index.analyse(&peptides, equate_il);
 
     let taxon_store = datastore.taxon_store();

--- a/api/src/controllers/mpa/pept2filtered.rs
+++ b/api/src/controllers/mpa/pept2filtered.rs
@@ -8,6 +8,7 @@ use crate::{
     helpers::fa_helper::{calculate_fa, FunctionalAggregation},
     AppState
 };
+use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
 pub struct Parameters {
@@ -41,6 +42,8 @@ async fn handler(
 
     peptides.sort();
     peptides.dedup();
+    let peptides = sanitize_peptides(peptides);
+
     let result = index.analyse(&peptides, equate_il);
 
     let taxa_set: HashSet<u32> = HashSet::from_iter(taxa.iter().cloned());

--- a/api/src/helpers/mod.rs
+++ b/api/src/helpers/mod.rs
@@ -9,3 +9,17 @@ pub mod tree_helper;
 fn is_zero(num: &u32) -> bool {
     *num == 0
 }
+
+pub fn sanitize_peptides(peptides: Vec<String>) -> Vec<String> {
+    peptides
+        .into_iter()
+        .map(|s| s.trim_end().to_uppercase())
+        .collect()
+}
+
+pub fn sanitize_proteins(proteins: Vec<String>) -> Vec<String> {
+    proteins
+        .into_iter()
+        .map(|s| s.trim_end().to_string())
+        .collect()
+}


### PR DESCRIPTION
This fixes issue #182 of the Unipept CLI, where newlines where not stripped from peptides