### PR TITLE
Increase protein match cutoff for API / CLI to 50k

### DIFF
--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -34,7 +34,7 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra }: Parameters
 ) -> Result<Vec<EcInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let ec_store = datastore.ec_store();
 

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -40,7 +40,7 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<FunctInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -36,7 +36,7 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<GoInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let go_store = datastore.go_store();
 

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -36,7 +36,7 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<InterproInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let interpro_store = datastore.interpro_store();
 

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -49,7 +49,7 @@ async fn handler(
     Parameters { input, equate_il, extra, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<LcaInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -50,7 +50,7 @@ async fn handler(
 ) -> Result<Vec<ProtInformation>, ApiError> {
     let connection = database.get_conn().await?;
 
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let accession_numbers: Vec<String> = result
         .iter()

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -48,7 +48,7 @@ async fn handler(
     Parameters { input, equate_il, extra, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<TaxaInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -59,7 +59,7 @@ async fn handler(
     Parameters { input, equate_il, extra, domains, names }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<PeptInformation>, ()> {
-    let result = index.analyse(&input, equate_il);
+    let result = index.analyse(&input, equate_il, None);
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -42,7 +42,7 @@ async fn handler(
 
     peptides.sort();
     peptides.dedup();
-    let result = index.analyse(&peptides, equate_il);
+    let result = index.analyse(&peptides, equate_il, Some(10_000));
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/mpa/pept2filtered.rs
+++ b/api/src/controllers/mpa/pept2filtered.rs
@@ -41,7 +41,7 @@ async fn handler(
 
     peptides.sort();
     peptides.dedup();
-    let result = index.analyse(&peptides, equate_il);
+    let result = index.analyse(&peptides, equate_il, Some(10_000));
 
     let taxa_set: HashSet<u32> = HashSet::from_iter(taxa.iter().cloned());
 

--- a/api/src/controllers/private_api/proteins.rs
+++ b/api/src/controllers/private_api/proteins.rs
@@ -51,7 +51,7 @@ async fn handler(
 ) -> Result<ProteinInformation, ApiError> {
     let connection = database.get_conn().await?;
 
-    let result = index.analyse(&vec![peptide], equate_il);
+    let result = index.analyse(&vec![peptide], equate_il, None);
 
     if result.is_empty() {
         return Ok(ProteinInformation::default());

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -35,7 +35,7 @@ impl Index {
     }
 
     pub fn analyse(&self, peptides: &Vec<String>, equate_il: bool, cutoff: Option<usize>) -> Vec<SearchResult> {
-        search_all_peptides(&self.searcher, peptides, cutoff.unwrap_or(10_000), equate_il)
+        search_all_peptides(&self.searcher, peptides, cutoff.unwrap_or(50_000), equate_il)
     }
 }
 

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -34,8 +34,8 @@ impl Index {
         Ok(Self { searcher })
     }
 
-    pub fn analyse(&self, peptides: &Vec<String>, equate_il: bool) -> Vec<SearchResult> {
-        search_all_peptides(&self.searcher, peptides, 10_000, equate_il)
+    pub fn analyse(&self, peptides: &Vec<String>, equate_il: bool, cutoff: Option<usize>) -> Vec<SearchResult> {
+        search_all_peptides(&self.searcher, peptides, cutoff.unwrap_or(10_000), equate_il)
     }
 }
 


### PR DESCRIPTION
For the LCA computation, we limit the amount of taxa (or proteins) that are considered to 10k since going over this number doesn't really make that much of a difference (the LCA will typically end up at root anyway). For the API  and CLI, where end users are interested in getting all results, we should increase the cutoff to 50 000 (which still is a limit, but safeguards our systems from completely drowning in some edge cases).