### PR TITLE
Add root taxon, and support for multiple descendant ranks

### DIFF
--- a/api/src/controllers/api/mod.rs
+++ b/api/src/controllers/api/mod.rs
@@ -29,7 +29,9 @@ pub fn default_names() -> bool {
 
 pub fn default_descendants() -> bool { false }
 
-pub fn default_descendants_rank() -> String { String::from("species") }
+pub fn default_descendants_ranks() -> Vec<String> {
+    vec![String::from("species")]
+}
 
 pub fn default_link() -> bool {
     false

--- a/api/src/helpers/lineage_helper/mod.rs
+++ b/api/src/helpers/lineage_helper/mod.rs
@@ -40,6 +40,14 @@ macro_rules! create_lineages {
                 })
             }
 
+            pub fn get_empty_lineage() -> Option<Lineage> {
+                 Some(Lineage {
+                    $(
+                        [<$field _id>]: None,
+                    )*
+                })
+            }
+
             pub fn get_lineage_array(taxon_id: u32, lineage_store: &LineageStore) -> Vec<Option<i32>> {
                 let lineage = lineage_store.get(taxon_id).cloned().unwrap_or_default();
 
@@ -57,6 +65,15 @@ macro_rules! create_lineages {
                     $(
                         [<$field _id>]: get_id(lineage.$field),
                         [<$field _name>]: get_name(lineage.$field, taxon_store)
+                    ),*
+                })
+            }
+
+            pub fn get_empty_lineage_with_names() -> Option<LineageWithNames> {
+                Some(LineageWithNames {
+                    $(
+                        [<$field _id>]: None,
+                        [<$field _name>]: String::from("")
                     ),*
                 })
             }
@@ -89,6 +106,13 @@ pub fn get_lineage(taxon_id: u32, version: LineageVersion, lineage_store: &Linea
     }
 }
 
+pub fn get_empty_lineage(version: LineageVersion) -> Option<Lineage> {
+    match version {
+        LineageVersion::V1 => v1::get_empty_lineage().map(Lineage::DefaultV1),
+        LineageVersion::V2 => v2::get_empty_lineage().map(Lineage::DefaultV2)
+    }
+}
+
 pub fn get_lineage_array(taxon_id: u32, version: LineageVersion, lineage_store: &LineageStore) -> Vec<Option<i32>> {
     match version {
         LineageVersion::V1 => v1::get_lineage_array(taxon_id, lineage_store),
@@ -105,6 +129,13 @@ pub fn get_lineage_with_names(
     match version {
         LineageVersion::V1 => v1::get_lineage_with_names(taxon_id, lineage_store, taxon_store).map(Lineage::NamesV1),
         LineageVersion::V2 => v2::get_lineage_with_names(taxon_id, lineage_store, taxon_store).map(Lineage::NamesV2)
+    }
+}
+
+pub fn get_empty_lineage_with_names(version: LineageVersion) -> Option<Lineage> {
+    match version {
+        LineageVersion::V1 => v1::get_empty_lineage_with_names().map(Lineage::NamesV1),
+        LineageVersion::V2 => v2::get_empty_lineage_with_names().map(Lineage::NamesV2)
     }
 }
 

--- a/datastore/src/lineage_store.rs
+++ b/datastore/src/lineage_store.rs
@@ -204,4 +204,11 @@ impl LineageStore {
             .and_then(|idx| self.index_references.get(idx))
             .and_then(|map| map.get(&taxon_id))
     }
+
+    /// Returns all unique taxon IDs at a specific rank in the NCBI taxonomy.
+    pub fn get_all_taxon_ids_at_rank(&self, rank: &str) -> Option<Vec<u32>> {
+        LineageStore::rank_to_idx(rank)
+            .and_then(|idx| self.index_references.get(idx))
+            .and_then(|map| Some(map.keys().cloned().collect()))
+    }
 }


### PR DESCRIPTION
This PR provides a fix for issue #50 and also allows end-users to select multiple descendant ranks at once when using the `descendants` option for the `api/taxonomy` endpoint.