### PR TITLE
Implement new private endpoint that allows to query and filter taxa

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ Follow these steps in order to easily work on the Unipept API in the devcontaine
 
 * You first have to build the binaries by running `cargo build --release`.
 * Then, you should start the mariadb server: `sudo service mariadb start`
-* Sometimes the password for the database user has not been initialized properly, open a MySQL shell and execute this command: `alter user 'root'@'localhost' identified by 'root_pass'; flush privileges;`.
+* Sometimes the password for the database user has not been initialized properly, open a MySQL shell and execute this command: `alter user 'root'@'localhost' identified by 'root_pass'; flush privileges;` (Note default user is `root`, default password is `root_pass`).
 * Finally, the Unipept API can be started with this command: `./target/release/unipept-api -i "/unipept-index-data" -d "mysql://root:root_pass@localhost:3306/unipept" -p 80`.

--- a/api/src/controllers/private_api/mod.rs
+++ b/api/src/controllers/private_api/mod.rs
@@ -4,6 +4,7 @@ pub mod interpros;
 pub mod metadata;
 pub mod proteins;
 pub mod taxa;
+pub mod taxa_filter;
 
 pub fn default_equate_il() -> bool {
     false

--- a/api/src/controllers/private_api/taxa_filter.rs
+++ b/api/src/controllers/private_api/taxa_filter.rs
@@ -1,0 +1,138 @@
+use axum::{extract::State, Json};
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    controllers::generate_handlers,
+    AppState
+};
+
+fn default_filter() -> String {
+    String::from("")
+}
+
+#[derive(Deserialize)]
+pub struct TaxaCountParameters {
+    #[serde(default = "default_filter")]
+    filter: String
+}
+
+#[derive(Deserialize)]
+pub struct TaxaFilterParameters {
+    #[serde(default = "default_filter")]
+    filter: String,
+    start: usize,
+    end: usize,
+    #[serde(default)]
+    sort_by: String, // Can be "id", "name", or "rank"
+    #[serde(default)]
+    sort_descending: bool,
+}
+
+#[derive(Serialize)]
+pub struct Taxon {
+    id: u32,
+    name: String,
+    rank: String,
+    lineage: Vec<Option<i32>>
+}
+
+#[derive(Serialize)]
+pub struct TaxonCountResult {
+    count: u32
+}
+
+async fn count_handler(
+    State(AppState { datastore, .. }): State<AppState>,
+    TaxaCountParameters { filter }: TaxaCountParameters,
+) -> Result<TaxonCountResult, ()> {
+    let taxon_store = datastore.taxon_store();
+
+    if (filter == "") {
+        Ok(TaxonCountResult {
+            count: taxon_store.mapper.len() as u32
+        })
+    } else {
+        Ok(TaxonCountResult {
+            count: taxon_store.mapper
+                .values()
+                .filter(|&(name, _, _)| name.to_lowercase().contains(&filter.to_lowercase()))
+                .count() as u32,
+        })
+    }
+}
+
+async fn filter_handler(
+    State(AppState { datastore, .. }): State<AppState>,
+    TaxaFilterParameters {
+        filter,
+        start,
+        end,
+        sort_by,
+        sort_descending,
+    }: TaxaFilterParameters,
+) -> Result<Vec<Taxon>, ()> {
+    let taxon_store = datastore.taxon_store();
+
+    let mut filtered_taxa: Vec<_> = taxon_store.mapper
+        .iter()
+        .filter(|(_, (name, _, _))| name.to_lowercase().contains(&filter.to_lowercase()))
+        .map(|(id, (name, rank, _))| Taxon {
+            id: *id,
+            name: name.clone(),
+            rank: rank.to_string(),
+            lineage: vec![], // Assuming lineage information is not present in the provided code
+        })
+        .collect();
+
+    // Sort based on the `sort_by` field
+    match sort_by.as_str() {
+        "name" => {
+            if sort_descending {
+                filtered_taxa.sort_by(|a, b| b.name.cmp(&a.name));
+            } else {
+                filtered_taxa.sort_by(|a, b| a.name.cmp(&b.name));
+            }
+        }
+        "rank" => {
+            if sort_descending {
+                filtered_taxa.sort_by(|a, b| b.rank.cmp(&a.rank));
+            } else {
+                filtered_taxa.sort_by(|a, b| a.rank.cmp(&b.rank));
+            }
+        }
+        _ => {
+            // Default to sorting by id
+            if sort_descending {
+                filtered_taxa.sort_by(|a, b| b.id.cmp(&a.id));
+            } else {
+                filtered_taxa.sort_by(|a, b| a.id.cmp(&b.id));
+            }
+        }
+    }
+
+    // Take the range [start, end)
+    let taxa: Vec<_> = filtered_taxa.into_iter().skip(start).take(end - start).collect();
+
+    Ok(taxa)
+}
+
+generate_handlers!(
+    async fn json_count_handler(
+        state => State<AppState>,
+        params => TaxaCountParameters
+    ) -> Result<Json<TaxonCountResult>, ()> {
+        Ok(Json(count_handler(state, params).await?))
+    }
+);
+
+generate_handlers!(
+    async fn json_filter_handler(
+        state => State<AppState>,
+        params => TaxaFilterParameters
+    ) -> Result<Json<Vec<Taxon>>, ()> {
+        Ok(Json(filter_handler(state, params).await?))
+    }
+);
+
+

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         datasets::sampledata,
         mpa::{pept2data, pept2filtered},
-        private_api::{ecnumbers, goterms, interpros, metadata, proteins, taxa}
+        private_api::{ecnumbers, goterms, interpros, metadata, proteins, taxa, taxa_filter}
     },
     middleware::{
         cors::create_cors_layer,
@@ -133,7 +133,11 @@ fn create_private_api_routes() -> Router<AppState> {
         "/proteins",
         get(proteins::get_json_handler).post(proteins::post_json_handler),
         "/taxa",
-        get(taxa::get_json_handler).post(taxa::post_json_handler)
+        get(taxa::get_json_handler).post(taxa::post_json_handler),
+        "/taxa/count",
+        get(taxa_filter::get_json_count_handler).post(taxa_filter::post_json_count_handler),
+        "/taxa/filter",
+        get(taxa_filter::get_json_filter_handler).post(taxa_filter::post_json_filter_handler)
     )
 }
 


### PR DESCRIPTION
The latest version of the Unipept Web Application now implements support for performing metaproteomics analyses on a subset of the UniProtKB database (a feature that's been ported from the Unipept Desktop application). In order to allow users to select which taxa should be present in a database, the web application needs to query all NCBI taxa from the Unipept API without specifying IDs. Instead, we allow users to enter a keyword and search through our database of taxa based on this keyword.

This PR implements two new private API endpoints for the Unipept API that accomodate for this:

1) `private_api/taxa/counts`: This endpoint accepts JSON objects with the `filter` property. This property is optional and expects a string that will be used to filter all taxa that contain this text in their name (capital insensitive). This endpoint allows you to figure out how many taxa match with the given filter and responds with a JSON-object that has one property `count`.

2) `private_api/taxa/filter`: Using the count information from the first endpoint, you can retrieve actual taxon information from the database with this endpoint that accepts JSON-objects with the following parameters:
    * `start` (required): The starting row index (inclusive).
    * `end` (required): The ending row index (exclusive).
    * `filter` (optional): A string to filter taxa by name, rank, or ID.
    * `sortBy` (optional): A string indicating the column to sort by. Default is id.
    * `sortDescending` (optional): A boolean to determine if sorting is descending. Default is false.
   
    Note: The endpoint will then answer with a list of taxa-objects containing. Note that a maximum of 100 objects can be requested at a time.