### PR TITLE
Add `report_taxa` option to `mpa/pept2data`

### DIFF
--- a/api/src/controllers/mpa/mod.rs
+++ b/api/src/controllers/mpa/mod.rs
@@ -7,3 +7,7 @@ pub fn default_equate_il() -> bool {
 pub fn default_include_fa() -> bool { false }
 
 pub fn default_tryptic() -> bool { false }
+
+pub fn default_report_taxa() -> bool {
+    false
+}


### PR DESCRIPTION
This PR adds a new option `report_taxa` (boolean, default value is `false`) that allows `pept2data` to also report a list of all taxa associated to a peptide. This taxon list also respects all of the potential filters that are set for this request (so if only bacteria are requested, the reported taxon list will also only contain bacterial taxa).

**Example request:**

```json
{
    "peptides": [
        "AALTER",
        "TTTVPWLELR",
        "AGPVLMEPLMK",
        "TGGLPYVGTGWYR",
        "TQDATHGNSLSHR",
        "VYFTADEAKAAHEAGER",
        "GAALSQNDNMLQMPLLTPVADETWGVK",
        "QGEGDKGTMKYEEFAK",
        "MLANAEEAGYKLLDRR"
    ],
    "report_taxa": true
}
```

**Example response:**

```json
{
    "peptides": [
        {
            "sequence": "AALTER",
            "lca": 1,
            "lineage": [
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null,
                null
            ],
            "fa": {
                "counts": {
                    "all": 63,
                    "EC": 48,
                    "GO": 63,
                    "IPR": 63
                },
                "data": {
                    "IPR:IPR013083": 1,
                    "IPR:IPR022911": 4,
                    "IPR:IPR045210": 1,
                    "IPR:IPR042183": 1,
                    "IPR:IPR007785": 1,
                    "IPR:IPR000741": 2,
                    "GO:0030259": 3,
                    ...
                }
            },
            "taxa": [
                4787,
                9606,
                176299,
                290402,
                66692,
                292415,
                391296,
                10090,
                10116
            ]
        }
    ]
}
```