### PR TITLE
Explicitly force deadpool to check db connection before using

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,22 +438,20 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-diesel"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ce884fff09b610fd0bbd9e9447327fda9f613d5bd1fa114f57905cbcfd8d27"
+checksum = "590573e9e29c5190a5ff782136f871e6e652e35d598a349888e028693601adf1"
 dependencies = [
  "deadpool",
  "deadpool-sync",
@@ -1448,12 +1446,6 @@ dependencies = [
  "web-sys",
  "windows-registry",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,20 +438,22 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.12.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
 dependencies = [
+ "async-trait",
  "deadpool-runtime",
  "num_cpus",
+ "retain_mut",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-diesel"
-version = "0.6.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590573e9e29c5190a5ff782136f871e6e652e35d598a349888e028693601adf1"
+checksum = "f9ce884fff09b610fd0bbd9e9447327fda9f613d5bd1fa114f57905cbcfd8d27"
 dependencies = [
  "deadpool",
  "deadpool-sync",
@@ -1446,6 +1448,12 @@ dependencies = [
  "web-sys",
  "windows-registry",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-deadpool-diesel = { version = "0.6.1", features = ["mysql"] }
+deadpool-diesel = { version = "0.4.1", features = ["mysql"] }
 diesel = { version = "2.2.8", features = ["mysql"] }
 itertools = "0.13.0"
 thiserror = "1.0"

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-deadpool-diesel = { version = "0.4.1", features = ["mysql"] }
+deadpool-diesel = { version = "0.6.1", features = ["mysql"] }
 diesel = { version = "2.2.8", features = ["mysql"] }
 itertools = "0.13.0"
 thiserror = "1.0"

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, ops::Deref};
 use std::collections::HashSet;
 use deadpool_diesel::mysql::{Manager, Object, Pool};
 pub use deadpool_diesel::InteractError;
+use deadpool_diesel::ManagerConfig;
 use diesel::{prelude::*, MysqlConnection, QueryDsl};
 pub use errors::DatabaseError;
 use models::UniprotEntry;
@@ -17,7 +18,9 @@ pub struct Database {
 
 impl Database {
     pub fn try_from_url(url: &str) -> Result<Self, DatabaseError> {
-        let manager = Manager::new(url, deadpool_diesel::Runtime::Tokio1);
+        let manager = Manager::from_config(url, deadpool_diesel::Runtime::Tokio1, ManagerConfig {
+            recycling_method: deadpool_diesel::RecyclingMethod::Verified
+        });
         let pool = Pool::builder(manager).build().map_err(|err| DatabaseError::BuildPoolError(err.to_string()))?;
         Ok(Self { pool })
     }


### PR DESCRIPTION
In a recent version of the deadpool-diesel package, a change caused errors to be ignored when they occur during database connection or querying. See this issue for more details: https://github.com/deadpool-rs/deadpool/issues/266
