### PR TITLE
Add private_api/proteomes endpoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "https://github.com/unipept/unipept-devcontainers/releases/download/v1.0.0/devcontainer-feature-unipept-index.tgz": {
+    "https://github.com/unipept/unipept-devcontainers/releases/download/v1.0.1/devcontainer-feature-unipept-index.tgz": {
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/rust:1": {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "database"
-version = "0.1.0"
+version = "2.3.2"
 dependencies = [
  "deadpool-diesel",
  "diesel",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "datastore"
-version = "0.1.0"
+version = "2.3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.1.0"
+version = "2.3.2"
 dependencies = [
  "sa-compression",
  "sa-index",

--- a/api/src/controllers/private_api/mod.rs
+++ b/api/src/controllers/private_api/mod.rs
@@ -6,6 +6,7 @@ pub mod proteins;
 pub mod taxa;
 pub mod taxa_filter;
 pub mod reference_proteomes;
+pub mod reference_proteomes_filter;
 
 pub fn default_equate_il() -> bool {
     false

--- a/api/src/controllers/private_api/mod.rs
+++ b/api/src/controllers/private_api/mod.rs
@@ -5,6 +5,7 @@ pub mod metadata;
 pub mod proteins;
 pub mod taxa;
 pub mod taxa_filter;
+pub mod reference_proteomes;
 
 pub fn default_equate_il() -> bool {
     false

--- a/api/src/controllers/private_api/reference_proteomes.rs
+++ b/api/src/controllers/private_api/reference_proteomes.rs
@@ -31,8 +31,7 @@ async fn handler(
                 datastore.reference_proteome_store().get(proteome).map(|(taxon_id, protein_count)| {
                     let taxon_name = datastore
                         .taxon_store()
-                        .get_name(*taxon_id)
-                        .map(|name| name.clone()) // Clone the &String to String
+                        .get_name(*taxon_id).cloned() // Clone the &String to String
                         .unwrap_or_else(|| "Unknown".to_string()); // Use `unwrap_or_else` for a default
 
                     ReferenceProteome {

--- a/api/src/controllers/private_api/reference_proteomes.rs
+++ b/api/src/controllers/private_api/reference_proteomes.rs
@@ -1,0 +1,58 @@
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use crate::{
+    controllers::generate_handlers,
+    AppState
+};
+
+#[derive(Serialize, Deserialize)]
+pub struct Parameters {
+    #[serde(default)]
+    proteomes: Vec<String>
+}
+
+#[derive(Serialize)]
+pub struct ReferenceProteome {
+    id: String,
+    taxon_id: u32,
+    taxon_name: String,
+    protein_count: u32
+}
+
+async fn handler(
+    State(AppState { datastore, .. }): State<AppState>,
+    Parameters { proteomes }: Parameters
+) -> Result<Vec<ReferenceProteome>, ()> {
+    Ok(
+        proteomes
+            .iter()
+            .map(|proteome| proteome.trim())
+            .filter_map(|proteome| {
+                datastore.reference_proteome_store().get(proteome).map(|(taxon_id, protein_count)| {
+                    let taxon_name = datastore
+                        .taxon_store()
+                        .get_name(*taxon_id)
+                        .map(|name| name.clone()) // Clone the &String to String
+                        .unwrap_or_else(|| "Unknown".to_string()); // Use `unwrap_or_else` for a default
+
+                    ReferenceProteome {
+                        id: proteome.to_string(),
+                        taxon_id: *taxon_id,
+                        taxon_name,
+                        protein_count: *protein_count,
+                    }
+
+                })
+            })
+            .collect()
+    )
+}
+
+generate_handlers!(
+    async fn json_handler(
+        state => State<AppState>,
+        params => Parameters
+    ) -> Result<Json<Vec<ReferenceProteome>>, ()> {
+        Ok(Json(handler(state, params).await?))
+    }
+);

--- a/api/src/controllers/private_api/reference_proteomes_filter.rs
+++ b/api/src/controllers/private_api/reference_proteomes_filter.rs
@@ -22,6 +22,8 @@ pub struct ReferenceProteomeFilterParameters {
     start: usize,
     end: usize,
     #[serde(default)]
+    sort_by: String, // Can be "id", "name", or "rank"
+    #[serde(default)]
     sort_descending: bool
 }
 
@@ -35,6 +37,7 @@ async fn count_handler(
     ReferenceProteomeCountParameters { filter }: ReferenceProteomeCountParameters
 ) -> Result<ReferenceProteomeCountResult, ()> {
     let proteome_store = datastore.reference_proteome_store();
+    let taxon_store = datastore.taxon_store();
     
     if filter.is_empty() {
         Ok(ReferenceProteomeCountResult {
@@ -45,8 +48,17 @@ async fn count_handler(
     } else {
         Ok(ReferenceProteomeCountResult {
             count: proteome_store.mapper
-                .keys()
-                .filter(|key| key.to_lowercase().contains(&filter.to_lowercase()))
+                .iter()
+                .filter(|(key, (taxon_id, _))| {
+                    let taxon_name = datastore
+                        .taxon_store()
+                        .get_name(*taxon_id).cloned() // Clone the &String to String
+                        .unwrap_or_else(|| "Unknown".to_string());
+
+                    key.to_lowercase().contains(&filter.to_lowercase()) ||
+                        taxon_id.to_string().contains(&filter) || 
+                        taxon_name.to_lowercase().contains(&filter.to_lowercase())
+                })
                 .count() as u32
         })
     }
@@ -58,24 +70,82 @@ async fn filter_handler(
         filter,
         start,
         end,
+        sort_by,
         sort_descending
     }: ReferenceProteomeFilterParameters
 ) -> Result<Vec<String>, ()> {
     let proteome_store = datastore.reference_proteome_store();
 
-    let mut filtered_proteomes: Vec<_> = proteome_store.mapper
-        .keys()
-        .filter(|key| key.to_lowercase().contains(&filter.to_lowercase()))
-        .map(|key| key.to_string())
+    let mut filtered_proteomes: Vec<(&String, &(u32, u32))> = proteome_store.mapper
+        .iter()
+        .filter(|(key, (taxon_id, _))| {
+            let taxon_name = datastore
+                .taxon_store()
+                .get_name(*taxon_id).cloned() // Clone the &String to String
+                .unwrap_or_else(|| "Unknown".to_string());
+
+            key.to_lowercase().contains(&filter.to_lowercase()) ||
+                taxon_id.to_string().contains(&filter) ||
+                taxon_name.to_lowercase().contains(&filter.to_lowercase())
+        })
         .collect();
 
-    if sort_descending {
-        filtered_proteomes.sort_by(|a, b| b.cmp(a));
-    } else {
-        filtered_proteomes.sort();
+    // Sort based on the `sort_by` field
+    match sort_by.as_str() {
+        "taxon_name" => {
+            if sort_descending {
+                filtered_proteomes.sort_by(|(_, &(a_taxon_id, _)), (_, &(b_taxon_id,_))| {
+                    let taxon_name_a = datastore
+                        .taxon_store()
+                        .get_name(a_taxon_id).cloned() // Clone the &String to String
+                        .unwrap_or_else(|| "Unknown".to_string());
+
+                    let taxon_name_b = datastore
+                        .taxon_store()
+                        .get_name(b_taxon_id).cloned() // Clone the &String to String
+                        .unwrap_or_else(|| "Unknown".to_string());
+                    taxon_name_b.cmp(&taxon_name_a)
+                });
+            } else {
+                filtered_proteomes.sort_by(|(_, &(a_taxon_id, _)), (_, &(b_taxon_id,_))| {
+                    let taxon_name_a = datastore
+                        .taxon_store()
+                        .get_name(a_taxon_id).cloned() // Clone the &String to String
+                        .unwrap_or_else(|| "Unknown".to_string());
+
+                    let taxon_name_b = datastore
+                        .taxon_store()
+                        .get_name(b_taxon_id).cloned() // Clone the &String to String
+                        .unwrap_or_else(|| "Unknown".to_string());
+                    taxon_name_a.cmp(&taxon_name_b)
+                });
+            }
+        },
+        "protein_count" => {
+            if sort_descending {
+                filtered_proteomes.sort_by(|(_, (_, a_protein_count)), (_, &(_, b_protein_count))| {
+                    b_protein_count.cmp(a_protein_count)
+                });
+            } else {
+                filtered_proteomes.sort_by(|(_, &(_, a_protein_count)), (_, (_, b_protein_count))| {
+                    a_protein_count.cmp(b_protein_count)
+                });
+            }
+        },
+        _ => {
+            if sort_descending {
+                filtered_proteomes.sort_by(|(a_proteome_id, _), (b_proteome_id, _)| {
+                    b_proteome_id.cmp(a_proteome_id)
+                });
+            } else {
+                filtered_proteomes.sort_by(|(a_proteome_id, _), (b_proteome_id, _)| {
+                    a_proteome_id.cmp(b_proteome_id)
+                });
+            }
+        },
     }
 
-    Ok(filtered_proteomes.into_iter().skip(start).take(end - start).collect())
+    Ok(filtered_proteomes.into_iter().skip(start).take(end - start).map(|(key, _)| key.to_string()).collect())
 }
 
 generate_handlers!(

--- a/api/src/controllers/private_api/reference_proteomes_filter.rs
+++ b/api/src/controllers/private_api/reference_proteomes_filter.rs
@@ -1,0 +1,52 @@
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use crate::{
+    controllers::generate_handlers,
+    AppState
+};
+
+fn default_filter() -> String {
+    String::from("")
+}
+
+#[derive(Deserialize)]
+pub struct ReferenceProteomeCountParameters {
+    #[serde(default = "default_filter")]
+    filter: String
+}
+
+#[derive(Serialize)]
+pub struct ReferenceProteomeCountResult {
+    count: u32
+}
+
+async fn count_handler(
+    State(AppState { datastore, .. }): State<AppState>,
+    ReferenceProteomeCountParameters { filter }: ReferenceProteomeCountParameters
+) -> Result<ReferenceProteomeCountResult, ()> {
+    let proteome_store = datastore.reference_proteome_store();
+    
+    if filter.is_empty() {
+        Ok(ReferenceProteomeCountResult {
+            count: proteome_store.mapper
+                .values()
+                .count() as u32
+        })
+    } else {
+        Ok(ReferenceProteomeCountResult {
+            count: proteome_store.mapper
+                .keys()
+                .filter(|key| key.to_lowercase().contains(&filter.to_lowercase()))
+                .count() as u32
+        })
+    }
+}
+
+generate_handlers!(
+    async fn json_count_handler(
+        state => State<AppState>,
+        params => ReferenceProteomeCountParameters
+    ) -> Result<Json<ReferenceProteomeCountResult>, ()> {
+        Ok(Json(count_handler(state, params).await?))
+    }
+);

--- a/api/src/controllers/private_api/reference_proteomes_filter.rs
+++ b/api/src/controllers/private_api/reference_proteomes_filter.rs
@@ -109,26 +109,22 @@ async fn filter_handler(
             });
         },
         "protein_count" => {
-            if sort_descending {
-                filtered_proteomes.sort_by(|(_, (_, a_protein_count)), (_, &(_, b_protein_count))| {
-                    b_protein_count.cmp(a_protein_count)
-                });
-            } else {
-                filtered_proteomes.sort_by(|(_, &(_, a_protein_count)), (_, (_, b_protein_count))| {
-                    a_protein_count.cmp(b_protein_count)
-                });
-            }
+            filtered_proteomes.sort_by(|(_, &(_, a_protein_count)), (_, &(_, b_protein_count))| {
+                if sort_descending {
+                    b_protein_count.cmp(&a_protein_count)
+                } else {
+                    a_protein_count.cmp(&b_protein_count)
+                }
+            });
         },
         _ => {
-            if sort_descending {
-                filtered_proteomes.sort_by(|(a_proteome_id, _), (b_proteome_id, _)| {
+            filtered_proteomes.sort_by(|(a_proteome_id, _), (b_proteome_id, _)| {
+                if sort_descending {
                     b_proteome_id.cmp(a_proteome_id)
-                });
-            } else {
-                filtered_proteomes.sort_by(|(a_proteome_id, _), (b_proteome_id, _)| {
-                    a_proteome_id.cmp(b_proteome_id)
-                });
-            }
+                } else {
+                    a_proteome_id.cmp(b_proteome_id) 
+                }
+            });
         },
     }
 

--- a/api/src/controllers/private_api/reference_proteomes_filter.rs
+++ b/api/src/controllers/private_api/reference_proteomes_filter.rs
@@ -15,6 +15,16 @@ pub struct ReferenceProteomeCountParameters {
     filter: String
 }
 
+#[derive(Deserialize)]
+pub struct ReferenceProteomeFilterParameters {
+    #[serde(default = "default_filter")]
+    filter: String,
+    start: usize,
+    end: usize,
+    #[serde(default)]
+    sort_descending: bool
+}
+
 #[derive(Serialize)]
 pub struct ReferenceProteomeCountResult {
     count: u32
@@ -42,11 +52,46 @@ async fn count_handler(
     }
 }
 
+async fn filter_handler(
+    State(AppState { datastore, .. }): State<AppState>,
+    ReferenceProteomeFilterParameters {
+        filter,
+        start,
+        end,
+        sort_descending
+    }: ReferenceProteomeFilterParameters
+) -> Result<Vec<String>, ()> {
+    let proteome_store = datastore.reference_proteome_store();
+
+    let mut filtered_proteomes: Vec<_> = proteome_store.mapper
+        .keys()
+        .filter(|key| key.to_lowercase().contains(&filter.to_lowercase()))
+        .map(|key| key.to_string())
+        .collect();
+
+    if sort_descending {
+        filtered_proteomes.sort_by(|a, b| b.cmp(a));
+    } else {
+        filtered_proteomes.sort();
+    }
+
+    Ok(filtered_proteomes.into_iter().skip(start).take(end - start).collect())
+}
+
 generate_handlers!(
     async fn json_count_handler(
         state => State<AppState>,
         params => ReferenceProteomeCountParameters
     ) -> Result<Json<ReferenceProteomeCountResult>, ()> {
         Ok(Json(count_handler(state, params).await?))
+    }
+);
+
+generate_handlers!(
+    async fn json_filter_handler(
+        state => State<AppState>,
+        params => ReferenceProteomeFilterParameters
+    ) -> Result<Json<Vec<String>>, ()> {
+        Ok(Json(filter_handler(state, params).await?))
     }
 );

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -28,6 +28,7 @@ pub async fn start(index_location: &str, database_address: &str, port: u32) -> R
     let ec_numbers = format!("{}/datastore/ec_numbers.tsv", index_location);
     let go_terms = format!("{}/datastore/go_terms.tsv", index_location);
     let interpro_entries = format!("{}/datastore/interpro_entries.tsv", index_location);
+    let reference_proteomes = format!("{}/datastore/reference_proteomes.tsv", index_location);
     let lineages = format!("{}/datastore/lineages.tsv", index_location);
     let taxons = format!("{}/datastore/taxons.tsv", index_location);
 
@@ -42,6 +43,7 @@ pub async fn start(index_location: &str, database_address: &str, port: u32) -> R
         &ec_numbers,
         &go_terms,
         &interpro_entries,
+        &reference_proteomes,
         &lineages,
         &taxons
     )?;

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         datasets::sampledata,
         mpa::{pept2data},
-        private_api::{ecnumbers, goterms, interpros, metadata, proteins, taxa, taxa_filter}
+        private_api::{ecnumbers, goterms, interpros, metadata, proteins, reference_proteomes, taxa, taxa_filter}
     },
     middleware::{
         cors::create_cors_layer,
@@ -148,6 +148,8 @@ fn create_private_api_routes() -> Router<AppState> {
         get(metadata::get_json_handler).post(metadata::post_json_handler),
         "/proteins",
         get(proteins::get_json_handler).post(proteins::post_json_handler),
+        "/proteomes",
+        get(reference_proteomes::get_json_handler).post(reference_proteomes::post_json_handler),
         "/taxa",
         get(taxa::get_json_handler).post(taxa::post_json_handler),
         "/taxa/count",

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         datasets::sampledata,
         mpa::{pept2data},
-        private_api::{ecnumbers, goterms, interpros, metadata, proteins, reference_proteomes, taxa, taxa_filter}
+        private_api::{ecnumbers, goterms, interpros, metadata, proteins, reference_proteomes, reference_proteomes_filter, taxa, taxa_filter}
     },
     middleware::{
         cors::create_cors_layer,
@@ -150,6 +150,8 @@ fn create_private_api_routes() -> Router<AppState> {
         get(proteins::get_json_handler).post(proteins::post_json_handler),
         "/proteomes",
         get(reference_proteomes::get_json_handler).post(reference_proteomes::post_json_handler),
+        "/proteomes/count",
+        get(reference_proteomes_filter::get_json_count_handler).post(reference_proteomes_filter::post_json_count_handler),
         "/taxa",
         get(taxa::get_json_handler).post(taxa::post_json_handler),
         "/taxa/count",

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -152,6 +152,8 @@ fn create_private_api_routes() -> Router<AppState> {
         get(reference_proteomes::get_json_handler).post(reference_proteomes::post_json_handler),
         "/proteomes/count",
         get(reference_proteomes_filter::get_json_count_handler).post(reference_proteomes_filter::post_json_count_handler),
+        "/proteomes/filter",
+        get(reference_proteomes_filter::get_json_filter_handler).post(reference_proteomes_filter::post_json_filter_handler),
         "/taxa",
         get(taxa::get_json_handler).post(taxa::post_json_handler),
         "/taxa/count",

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "database"
-version = "0.1.0"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]

--- a/datastore/Cargo.toml
+++ b/datastore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datastore"
-version = "0.1.0"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]

--- a/datastore/src/errors.rs
+++ b/datastore/src/errors.rs
@@ -12,6 +12,8 @@ pub enum DataStoreError {
     GoStoreError(#[from] GoStoreError),
     #[error("Interpro store error: {0}")]
     InterproStoreError(#[from] InterproStoreError),
+    #[error("Reference proteome store error: {0}")]
+    ReferenceProteomeStoreError(#[from] ReferenceProteomeStoreError),
     #[error("Lineage store error: {0}")]
     LineageStoreError(#[from] LineageStoreError),
     #[error("Taxon store error: {0}")]
@@ -50,6 +52,16 @@ pub enum InterproStoreError {
     IoError(#[from] std::io::Error),
     #[error("File not found: {0}")]
     FileNotFound(String)
+}
+
+#[derive(Error, Debug)]
+pub enum ReferenceProteomeStoreError {
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
+    #[error("File not found: {0}")]
+    FileNotFound(String),
+    #[error("Error while parsing: {0}")]
+    ParseError(String),
 }
 
 #[derive(Error, Debug)]

--- a/datastore/src/lib.rs
+++ b/datastore/src/lib.rs
@@ -28,6 +28,7 @@ pub struct DataStore {
 }
 
 impl DataStore {
+    #[allow(clippy::too_many_arguments)]
     pub fn try_from_files(
         version_file: &str,
         sample_file: &str,

--- a/datastore/src/lib.rs
+++ b/datastore/src/lib.rs
@@ -5,6 +5,7 @@ mod interpro_store;
 mod lineage_store;
 mod sample_store;
 mod taxon_store;
+mod reference_proteome_store;
 
 pub use ec_store::EcStore;
 pub use errors::DataStoreError;
@@ -13,6 +14,7 @@ pub use interpro_store::InterproStore;
 pub use lineage_store::{Lineage, LineageStore};
 pub use sample_store::SampleStore;
 pub use taxon_store::{LineageRank, TaxonStore};
+pub use reference_proteome_store::ReferenceProteomeStore;
 
 pub struct DataStore {
     version: String,
@@ -20,6 +22,7 @@ pub struct DataStore {
     ec_store: EcStore,
     go_store: GoStore,
     interpro_store: InterproStore,
+    reference_proteome_store: ReferenceProteomeStore,
     lineage_store: LineageStore,
     taxon_store: TaxonStore
 }
@@ -31,6 +34,7 @@ impl DataStore {
         ec_file: &str,
         go_file: &str,
         interpro_file: &str,
+        reference_proteome_file: &str,
         lineage_file: &str,
         taxon_file: &str
     ) -> Result<Self, DataStoreError> {
@@ -43,6 +47,7 @@ impl DataStore {
             ec_store: EcStore::try_from_file(ec_file)?,
             go_store: GoStore::try_from_file(go_file)?,
             interpro_store: InterproStore::try_from_file(interpro_file)?,
+            reference_proteome_store: ReferenceProteomeStore::try_from_file(reference_proteome_file)?,
             lineage_store: LineageStore::try_from_file(lineage_file)?,
             taxon_store: TaxonStore::try_from_file(taxon_file)?
         })
@@ -67,6 +72,8 @@ impl DataStore {
     pub fn interpro_store(&self) -> &InterproStore {
         &self.interpro_store
     }
+    
+    pub fn reference_proteome_store(&self) -> &ReferenceProteomeStore { &self.reference_proteome_store }
 
     pub fn lineage_store(&self) -> &LineageStore {
         &self.lineage_store

--- a/datastore/src/reference_proteome_store.rs
+++ b/datastore/src/reference_proteome_store.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use crate::errors::ReferenceProteomeStoreError;
+
+// taxon ID, protein count
+pub type ReferenceProteomeDescription = (u32, u32);
+
+#[derive(Clone)]
+pub struct ReferenceProteomeStore {
+    mapper: HashMap<String, ReferenceProteomeDescription>
+}
+
+impl ReferenceProteomeStore {
+    pub fn try_from_file(file: &str) -> Result<Self, ReferenceProteomeStoreError> {
+        let file = std::fs::File::open(file).map_err(
+            |_| ReferenceProteomeStoreError::FileNotFound(file.to_string())
+        )?;
+
+        let mut mapper = HashMap::new();
+        for line in BufReader::new(file).lines() {
+            let line = line?;
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() == 4 {
+                let taxon_id = parts[2].parse::<u32>().map_err(|_| ReferenceProteomeStoreError::ParseError(format!("Could not parse taxon ID: {}", parts[2])))?;
+                let protein_count = parts[3].parse::<u32>().map_err(|_| ReferenceProteomeStoreError::ParseError(format!("Could not parse protein count: {}", parts[3])))?;
+                mapper.insert(parts[1].to_string(), (taxon_id, protein_count));
+            }
+        }
+
+        Ok(ReferenceProteomeStore { mapper })
+    }
+
+    pub fn get(&self, key: &str) -> Option<&ReferenceProteomeDescription> {
+        self.mapper.get(key)
+    }
+    
+    pub fn get_taxon_id(&self, key: &str) -> Option<u32> {
+        self.mapper.get(key).map(|(taxon_id, _)| *taxon_id)
+    }
+    
+    pub fn get_protein_count(&self, key: &str) -> Option<u32> {
+        self.mapper.get(key).map(|(_, protein_count)| *protein_count)
+    }
+}

--- a/datastore/src/reference_proteome_store.rs
+++ b/datastore/src/reference_proteome_store.rs
@@ -7,7 +7,7 @@ pub type ReferenceProteomeDescription = (u32, u32);
 
 #[derive(Clone)]
 pub struct ReferenceProteomeStore {
-    mapper: HashMap<String, ReferenceProteomeDescription>
+    pub mapper: HashMap<String, ReferenceProteomeDescription>
 }
 
 impl ReferenceProteomeStore {

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "index"
-version = "0.1.0"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This PR implements a few new endpoints for the private API that allow us to query UniProt reference proteomes.

These endpoints have been implemented:

# `/private_api/proteomes`
Accepts a JSON-object with a property `proteomes` that is a list of UniProt reference proteome identifiers. The endpoint will then respond with an object for each of the requested proteomes containing the associated taxon id and protein count.

## Example
**Input**
```json
{
    "proteomes": [
        "UP000000296",
        "UP000000558"
    ]
}
```

```json
[
    {
        "id": "UP000000296",
        "taxon_id": 1048207,
        "taxon_name": "Escherichia phage phiEB49",
        "protein_count": 74
    },
    {
        "id": "UP000000558",
        "taxon_id": 83334,
        "taxon_name": "Escherichia coli O157:H7",
        "protein_count": 5057
    }
]
```

# `/private_api/proteomes/count`
Accepts a JSON-object with a property `filter`. The endpoint will count how many reference proteomes exist that contain the value provided by the `filter` property in their name.

## Example
**Input**
```json
{
    "filter": "escherichia"
}
```

**Output**
```json
{
    "count": 324
}
```

# `/private_api/proteomes/filter`
Accepts a JSON-object with a property `filter`, a `start`, `end` and `sort_descending` parameters. The endpoint will return (paginated) all UniProt reference proteome IDs that match the provided filter.

## Example
**Input**
```json
{
    "filter": "escherichia",
    "start": 0,
    "end": 10
}
```

**Output**
```json
[
    "UP000000296",
    "UP000000558",
    "UP000000617",
    "UP000000625",
    "UP000000746",
    "UP000000747",
    "UP000000786",
    "UP000000840",
    "UP000000876",
    "UP000000983"
]
```