### PR TITLE
Add private_api/proteins/count and private_api/proteins/filter endpoints

### DIFF
--- a/api/src/controllers/private_api/mod.rs
+++ b/api/src/controllers/private_api/mod.rs
@@ -5,6 +5,7 @@ pub mod metadata;
 pub mod proteins;
 pub mod taxa;
 pub mod taxa_filter;
+pub mod proteins_filter;
 
 pub fn default_equate_il() -> bool {
     false

--- a/api/src/controllers/private_api/proteins.rs
+++ b/api/src/controllers/private_api/proteins.rs
@@ -16,7 +16,7 @@ pub struct Parameters {
 
 #[derive(Serialize)]
 pub struct Protein {
-    uniprot_accession_id: u32,
+    uniprot_accession_id: String,
     name: String,
     taxon_id: u32,
     db_type: String
@@ -33,7 +33,7 @@ async fn handler(
     Ok(entries
         .into_iter()
         .map(|entry| Protein {
-            uniprot_accession_id: entry.id,
+            uniprot_accession_id: entry.uniprot_accession_number,
             name: entry.name,
             taxon_id: entry.taxon_id,
             db_type: entry.db_type,

--- a/api/src/controllers/private_api/proteins.rs
+++ b/api/src/controllers/private_api/proteins.rs
@@ -1,117 +1,51 @@
 use std::collections::HashSet;
 use axum::{extract::State, Json};
-use database::get_accessions_map;
 use serde::{Deserialize, Serialize};
-
+use database::get_accessions;
 use crate::{
     controllers::generate_handlers,
     errors::ApiError,
-    helpers::{
-        lca_helper::calculate_lca,
-        lineage_helper::{get_lineage_array, LineageVersion}
-    },
     AppState
 };
 
 #[derive(Deserialize)]
 pub struct Parameters {
-    peptide: String,
-    equate_il: bool
-}
-
-#[derive(Serialize)]
-pub struct ProteinInformation {
-    lca: i32,
-    common_lineage: Vec<i32>,
-    proteins: Vec<Protein>
+    #[serde(default)]
+    accessions: Vec<String>
 }
 
 #[derive(Serialize)]
 pub struct Protein {
-    #[serde(rename = "uniprotAccessionId")]
-    uniprot_accession_id: String,
+    uniprot_accession_id: u32,
     name: String,
-    organism: u32,
-    #[serde(rename = "ecNumbers")]
-    ec_numbers: Vec<String>,
-    #[serde(rename = "goTerms")]
-    go_terms: Vec<String>,
-    #[serde(rename = "interproEntries")]
-    interpro_entries: Vec<String>
-}
-
-impl Default for ProteinInformation {
-    fn default() -> Self {
-        ProteinInformation { lca: -1, common_lineage: vec![], proteins: vec![] }
-    }
+    taxon_id: u32,
+    db_type: String
 }
 
 async fn handler(
-    State(AppState { index, datastore, database }): State<AppState>,
-    Parameters { peptide, equate_il }: Parameters
-) -> Result<ProteinInformation, ApiError> {
+    State(AppState { database, .. }): State<AppState>,
+    Parameters { accessions }: Parameters
+) -> Result<Vec<Protein>, ApiError> {
     let connection = database.get_conn().await?;
 
-    let result = index.analyse(&vec![peptide], equate_il, false, None);
+    let entries = connection.interact(move |conn| get_accessions(conn, &HashSet::from_iter(accessions.iter().cloned()))).await??;
 
-    if result.is_empty() {
-        return Ok(ProteinInformation::default());
-    }
-
-    let accession_numbers: HashSet<String> =
-        result[0].proteins.iter().map(|protein| protein.uniprot_accession.clone()).collect();
-
-    let accessions_map = connection.interact(move |conn| get_accessions_map(conn, &accession_numbers)).await??;
-
-    let taxon_store = datastore.taxon_store();
-    let lineage_store = datastore.lineage_store();
-
-    let taxa = result[0].proteins.iter().map(|protein| protein.taxon).collect();
-    let lca = calculate_lca(taxa, LineageVersion::V2, taxon_store, lineage_store);
-
-    let common_lineage = get_lineage_array(lca as u32, LineageVersion::V2, lineage_store)
-        .iter()
-        .filter_map(|taxon_id| *taxon_id)
-        .collect::<Vec<i32>>();
-
-    Ok(ProteinInformation {
-        lca,
-        common_lineage,
-        proteins: result[0]
-            .proteins
-            .iter()
-            .filter_map(|protein| {
-                let uniprot_entry = accessions_map.get(&protein.uniprot_accession)?;
-
-                let fa: Vec<&str> = uniprot_entry.fa.split(';').collect();
-                let ec_numbers =
-                    fa.iter().filter(|key| key.starts_with("EC:")).map(ToString::to_string).collect::<Vec<String>>();
-                let go_terms =
-                    fa.iter().filter(|key| key.starts_with("GO:")).map(ToString::to_string).collect::<Vec<String>>();
-                let interpro_entries = fa
-                    .iter()
-                    .filter(|key| key.starts_with("IPR:"))
-                    .map(|k| k[4..].to_string())
-                    .collect::<Vec<String>>();
-
-                Some(Protein {
-                    uniprot_accession_id: protein.uniprot_accession.clone(),
-                    name: uniprot_entry.name.clone(),
-                    organism: uniprot_entry.taxon_id,
-                    ec_numbers,
-                    go_terms,
-                    interpro_entries
-                })
-            })
-            .collect()
-    })
+    Ok(entries
+        .into_iter()
+        .map(|entry| Protein {
+            uniprot_accession_id: entry.id,
+            name: entry.name,
+            taxon_id: entry.taxon_id,
+            db_type: entry.db_type,
+        })
+        .collect())
 }
 
 generate_handlers!(
     async fn json_handler(
         state => State<AppState>,
         params => Parameters
-    ) -> Result<Json<ProteinInformation>, ApiError> {
+    ) -> Result<Json<Vec<Protein>>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/api/src/controllers/private_api/proteins_filter.rs
+++ b/api/src/controllers/private_api/proteins_filter.rs
@@ -1,0 +1,73 @@
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use database::{get_accessions_by_filter, get_accessions_count_by_filter};
+use crate::{
+    controllers::generate_handlers,
+    AppState
+};
+use crate::errors::ApiError;
+
+fn default_filter() -> String {
+    String::from("")
+}
+
+fn default_sort_by() -> String { 
+    String::from("uniprot_accession_id") 
+}
+
+#[derive(Deserialize)]
+pub struct ProteinCountParameters {
+    #[serde(default = "default_filter")]
+    filter: String
+}
+
+#[derive(Deserialize)]
+pub struct ProteinFilterParameters {
+    #[serde(default = "default_filter")]
+    filter: String,
+    start: usize,
+    end: usize,
+    #[serde(default = "default_sort_by")]
+    sort_by: String,
+    #[serde(default)]
+    sort_descending: bool
+}
+
+#[derive(Serialize)]
+pub struct ProteinCountResult {
+    count: u32
+}
+
+async fn count_handler(
+    State(AppState { database, .. }): State<AppState>,
+    ProteinCountParameters { filter }:  ProteinCountParameters
+) -> Result<ProteinCountResult, ApiError> {
+    let connection = database.get_conn().await?;
+    Ok(ProteinCountResult { count: connection.interact(move |conn| get_accessions_count_by_filter(conn, filter)).await?? })
+}
+
+async fn filter_handler(
+    State(AppState { database, .. }): State<AppState>,
+    ProteinFilterParameters { filter, start, end, sort_by, sort_descending }:  ProteinFilterParameters
+) -> Result<Vec<String>, ApiError> {
+    let connection = database.get_conn().await?;
+    Ok(connection.interact(move |conn| get_accessions_by_filter(conn, filter, start, end, sort_by, sort_descending)).await??)
+}
+
+generate_handlers!(
+    async fn json_count_handler(
+        state => State<AppState>,
+        params => ProteinCountParameters
+    ) -> Result<Json<ProteinCountResult>, ApiError> {
+        Ok(Json(count_handler(state, params).await?))
+    }
+);
+
+generate_handlers!(
+    async fn json_filter_handler(
+        state => State<AppState>,
+        params => ProteinFilterParameters
+    ) -> Result<Json<Vec<String>>, ApiError> {
+        Ok(Json(filter_handler(state, params).await?))
+    }
+);

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         datasets::sampledata,
         mpa::{pept2data},
-        private_api::{ecnumbers, goterms, interpros, metadata, proteins, taxa, taxa_filter}
+        private_api::{ecnumbers, goterms, interpros, metadata, proteins, proteins_filter, taxa, taxa_filter}
     },
     middleware::{
         cors::create_cors_layer,
@@ -148,6 +148,10 @@ fn create_private_api_routes() -> Router<AppState> {
         get(metadata::get_json_handler).post(metadata::post_json_handler),
         "/proteins",
         get(proteins::get_json_handler).post(proteins::post_json_handler),
+        "/proteins/count",
+        get(proteins_filter::get_json_count_handler).post(proteins_filter::post_json_count_handler),
+        "/proteins/filter",
+        get(proteins_filter::get_json_filter_handler).post(proteins_filter::post_json_filter_handler),
         "/taxa",
         get(taxa::get_json_handler).post(taxa::post_json_handler),
         "/taxa/count",

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -126,11 +126,10 @@ pub fn get_accessions_count_by_filter(
 
     #[derive(QueryableByName)]
     struct CountResult {
-        #[sql_type = "diesel::sql_types::BigInt"]
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
         total_count: i64,
     }
-
-
+    
     let query: CountResult = sql_query(
         "SELECT COUNT(*) AS total_count FROM (
             SELECT `uniprot_entries`.`uniprot_accession_number`

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -4,7 +4,7 @@ use deadpool_diesel::mysql::{Manager, Object, Pool};
 pub use deadpool_diesel::InteractError;
 use deadpool_diesel::ManagerConfig;
 use diesel::{prelude::*, sql_query, MysqlConnection, QueryDsl};
-use diesel::sql_types::{BigInt, Integer, Text, Unsigned};
+use diesel::sql_types::{Integer, Text, Unsigned};
 pub use errors::DatabaseError;
 use models::UniprotEntry;
 use itertools::Itertools;
@@ -118,8 +118,6 @@ pub fn get_accessions_count_by_filter(
     conn: &mut MysqlConnection,
     filter: String,
 ) -> Result<u32, DatabaseError> {
-    use schema::uniprot_entries::dsl::*;
-
     if filter.is_empty() {
         return Ok(COUNT_THRESHOLD);
     }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -38,9 +38,19 @@ impl Deref for Database {
     }
 }
 
+/// Retrieves protein information from the database for a given set of UniProt accession IDs
+///
+/// # Arguments
+/// * `conn` - Database connection handle 
+/// * `accessions` - Set of UniProt accession IDs to retrieve data for
+///
+/// # Returns
+/// * Vector of `UniprotEntry` records containing protein info from the database, ordered to match
+///   the order of accessions in the input set
+/// * `DatabaseError` if the database operation fails
 pub fn get_accessions(
     conn: &mut MysqlConnection,
-    accessions: &HashSet<String>
+    accessions: &HashSet<String>,
 ) -> Result<Vec<UniprotEntry>, DatabaseError> {
     use schema::uniprot_entries::dsl::*;
 
@@ -60,12 +70,129 @@ pub fn get_accessions(
     Ok(result)
 }
 
+/// Gets protein information as a map with UniProt accession IDs as keys and UniprotEntry objects as values
+///
+/// # Arguments
+/// * `conn` - Database connection handle
+/// * `accessions` - Set of UniProt accession IDs to retrieve data for
+///
+/// # Returns
+/// * HashMap mapping UniProt accession IDs to their corresponding UniprotEntry records
+/// * `DatabaseError` if the database operation fails
+///
+/// This function returns the same protein information as `get_accessions()` but organized as a lookup map
+/// instead of a vector, allowing direct access to entries by their accession ID.
 pub fn get_accessions_map(
     conn: &mut MysqlConnection,
-    accessions: &HashSet<String>
+    accessions: &HashSet<String>,
 ) -> Result<HashMap<String, UniprotEntry>, DatabaseError> {
     Ok(get_accessions(conn, accessions)?
         .into_iter()
         .map(|entry| (entry.uniprot_accession_number.clone(), entry))
         .collect())
+}
+
+/// Counts the number of UniProt entries in the database that match the given filter string
+///
+/// # Arguments
+/// * `conn` - Database connection handle
+/// * `filter` - String to filter entries by. If empty, returns total count of all entries
+///
+/// # Returns
+/// * Number of matching entries (as u32)
+/// * `DatabaseError` if the database operation fails
+///
+/// This function counts UniProt entries where either:
+/// - Entry name contains the filter string (case-sensitive)
+/// - UniProt accession number contains the filter string 
+/// - Database type contains the filter string
+/// - Taxon ID exactly matches filter string if it can be parsed as u32
+///
+/// The filter is applied as a partial match (using SQL LIKE with wildcards),
+/// except for taxon_id which requires an exact match.
+pub fn get_accessions_count_by_filter(
+    conn: &mut MysqlConnection,
+    filter: String,
+) -> Result<u32, DatabaseError> {
+    use schema::uniprot_entries::dsl::*;
+
+    if filter.is_empty() {
+        return Ok(uniprot_entries.count().get_result::<i64>(conn)? as u32);
+    }
+
+    let filter_pattern = format!("%{}%", filter);
+
+    Ok(uniprot_entries
+        .filter(
+            name.like(&filter_pattern)
+                .or(uniprot_accession_number.like(&filter_pattern))
+                .or(db_type.like(&filter_pattern))
+                // TODO update this taxon id filter such that it also works for organism names (and for matching parts of the ID instead of the complete integer)
+                .or(taxon_id.eq(filter.parse::<u32>().unwrap_or(0)))
+        )
+        .count()
+        .get_result::<i64>(conn)? as u32)
+}
+
+/// Gets UniProt accession IDs from the database that match the given filter criteria
+///
+/// # Arguments
+/// * `conn` - Database connection handle
+/// * `filter` - String to filter entries by. If empty, returns unfiltered results
+/// * `start` - Starting index for pagination
+/// * `end` - Ending index for pagination 
+/// * `sort_by` - Field to sort results by (name, uniprot_accession_number, db_type, or taxon_id)
+/// * `sort_descending` - Whether to sort in descending order
+///
+/// # Returns
+/// * Vector of UniProt accession IDs that match the filter criteria
+/// * `DatabaseError` if the database operation fails
+///
+/// This function returns UniProt accession IDs where either:
+/// - Entry name contains the filter string (case-sensitive)
+/// - UniProt accession number contains the filter string
+/// - Database type contains the filter string
+/// - Taxon ID exactly matches filter string if it can be parsed as u32
+///
+/// The filter is applied as a partial match (using SQL LIKE with wildcards),
+/// except for taxon_id which requires an exact match.
+/// Results are paginated based on start/end indices and can be sorted by the specified field.
+pub fn get_accessions_by_filter(
+    conn: &mut MysqlConnection,
+    filter: String,
+    start: usize,
+    end: usize,
+    sort_by: String,
+    sort_descending: bool,
+) -> Result<Vec<String>, DatabaseError> {
+    use schema::uniprot_entries::dsl::*;
+
+    let filter_pattern = format!("%{}%", filter);
+
+    let mut query = uniprot_entries.select(uniprot_accession_number).into_boxed();
+
+    if !filter.is_empty() {
+        query = query.filter(
+            name.like(&filter_pattern)
+                .or(uniprot_accession_number.like(&filter_pattern))
+                .or(db_type.like(&filter_pattern))
+                .or(taxon_id.eq(filter.parse::<u32>().unwrap_or(0)))
+        );
+    }
+
+    // Apply sorting
+    if !sort_by.is_empty() {
+        query = match sort_by.as_str() {
+            "name" => if sort_descending { query.order(name.desc()) } else { query.order(name.asc()) },
+            "uniprot_accession_number" => if sort_descending { query.order(uniprot_accession_number.desc()) } else { query.order(uniprot_accession_number.asc()) },
+            "db_type" => if sort_descending { query.order(db_type.desc()) } else { query.order(db_type.asc()) },
+            "taxon_id" => if sort_descending { query.order(taxon_id.desc()) } else { query.order(taxon_id.asc()) },
+            _ => query
+        };
+    }
+
+    // Apply pagination
+    query = query.offset(start as i64).limit((end - start) as i64);
+
+    Ok(query.load::<String>(conn)?)
 }


### PR DESCRIPTION
This PR implements two new private_api endpoints for the proteins, and makes changes to the output and input of the existing `private_api/proteins` endpoint.

# `private_api/proteins`
The existing implementation has been replaced. If all proteins that match a given peptide are required, you should use `api/v2/pept2prot` instead of `private_api/proteins`. The new implementation of this endpoint requires a JSON-object with one key `accessions`. This is a list of UniProt accession IDs for which the name, db_type and taxon will be returned.

## Example
**Input**
```json
{
    "accessions": [
        "Q12031",
        "B2FLM6"
    ]
}
```

**Output**
```json
[
    {
        "uniprot_accession_id": 357,
        "name": "Pimeloyl-[acyl-carrier protein] methyl ester esterase",
        "taxon_id": 522373,
        "db_type": "swissprot"
    },
    {
        "uniprot_accession_id": 49,
        "name": "Mitochondrial 2-methylisocitrate lyase ICL2",
        "taxon_id": 559292,
        "db_type": "swissprot"
    }
]
```

# `private_api/proteins/count`
A new endpoint that accepts one filter argument (string). It will then return the amount of UniProtKB entries in the Unipept database that match the filter. This endpoint counts UniProt entries where either:
* Entry name contains the filter string (case-sensitive)
* UniProt accession number contains the filter string 
* Database type contains the filter string
* Taxon ID exactly matches filter string if it can be parsed as an integer

**NOTE:** This endpoint will return either the correct count if less than 100 000 entries match, or 100 000 if it's more.

## Example
**Input**
```json
{
    "filter": "methyl"
}
```

**Output**
```json
{
    "count": 25526
}
```

# `private_api/proteins/filter`
A new endpoint that accepts a filter argument (string) and then information required to perform correct pagination of the returned results (`start`: required, `end`: required, `sort_by`: optional and `sort_descending`: optional). It will return all UniProt accession IDs of the UniProtKB entries in the Unipept database that match the filter and are in between the given bounds. Endpoint returns accession IDs where either:
* Entry name contains the filter string (case-sensitive)
* UniProt accession number contains the filter string 
* Database type contains the filter string
* Taxon ID exactly matches filter string if it can be parsed as an integer

## Example
**Input**
```json
{
    "filter": "methyl",
    "start": 0,
    "end": 10,
    "sort_by": "uniprot_accession_id",
    "sort_descending": true
}
```

```json
[
    "Q12031",
    "B2FLM6",
    "B5QYY9",
    "P54839",
    "B0R515",
    "Q39KT9",
    "B5BFM0",
    "C0PY28",
    "B6YS43",
    "C3LFJ0"
]
```