### PR TITLE
Update API to use FULLTEXT index on uniprot_entries table

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -197,13 +197,13 @@ pub fn get_accessions_by_filter(
     let base_query = {
         let mut sql = String::from(
             "SELECT `uniprot_entries`.`uniprot_accession_number` \
-            FROM `uniprot_entries` WHERE ",
+            FROM `uniprot_entries` ",
         );
 
         // Build conditions for FILTER (MATCH, taxon_id)
         if !filter.is_empty() {
             sql.push_str(
-                "(MATCH(`uniprot_entries`.`name`) AGAINST (? IN BOOLEAN MODE) \
+                " WHERE (MATCH(`uniprot_entries`.`name`) AGAINST (? IN BOOLEAN MODE) \
                 OR MATCH(`uniprot_entries`.`uniprot_accession_number`) AGAINST (? IN BOOLEAN MODE) \
                 OR `uniprot_entries`.`taxon_id` = ?) ",
             );

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -173,6 +173,7 @@ pub fn get_accessions_count_by_filter(
 /// The filter is applied as a partial match (using SQL LIKE with wildcards),
 /// except for taxon_id which requires an exact match.
 /// Results are paginated based on start/end indices and can be sorted by the specified field.
+#[allow(clippy::needless_late_init)]
 pub fn get_accessions_by_filter(
     conn: &mut MysqlConnection,
     filter: String,


### PR DESCRIPTION
Because search performance for the `/private_api/proteins/count` and `/private_api/proteins/filter` endpoints was poor, I've updated the `uniprot_entries` table and added a FULLTEXT index on the `name` and `uniprot_accession_number` columns.

This index allows us to retrieve matching proteins much faster. This PR updates the SQL-queries that are performed by the Unipept API on this proteins table and drastically improves its performance as a direct result.

We've dropped support for filtering and sorting the proteins by database type in this PR.