### PR TITLE
Reduce peak memory on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "bitarray"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git#26dd5e55aba846313dc276abf3eb8e0f02f0abf3"
+source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
 
 [[package]]
 name = "bitflags"
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "fa-compression"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git#26dd5e55aba846313dc276abf3eb8e0f02f0abf3"
+source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
 
 [[package]]
 name = "fastrand"
@@ -1685,7 +1685,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "sa-compression"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git#26dd5e55aba846313dc276abf3eb8e0f02f0abf3"
+source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#30121ce41057607fe153799ae471a5d769eef584"
 dependencies = [
  "bitarray",
  "sa-index",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "sa-index"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git#26dd5e55aba846313dc276abf3eb8e0f02f0abf3"
+source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
  "clap",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "sa-mappings"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git#26dd5e55aba846313dc276abf3eb8e0f02f0abf3"
+source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
  "bytelines",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "text-compression"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git#26dd5e55aba846313dc276abf3eb8e0f02f0abf3"
+source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
 ]

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.3.2"
 edition = "2021"
 
 [dependencies]
-sa-compression = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
-sa-index = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
-sa-mappings = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
+sa-compression = { git = "https://github.com/unipept/unipept-index.git" }
+sa-index = { git = "https://github.com/unipept/unipept-index.git" }
+sa-mappings = { git = "https://github.com/unipept/unipept-index.git" }
 thiserror = "1.0"

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.3.2"
 edition = "2021"
 
 [dependencies]
-sa-compression = { git = "https://github.com/unipept/unipept-index.git" }
+sa-compression = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
 sa-index = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
-sa-mappings = { git = "https://github.com/unipept/unipept-index.git" }
+sa-mappings = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
 thiserror = "1.0"

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 sa-compression = { git = "https://github.com/unipept/unipept-index.git" }
-sa-index = { git = "https://github.com/unipept/unipept-index.git" }
+sa-index = { git = "https://github.com/unipept/unipept-index.git", branch = "feature/improve-peak-memory" }
 sa-mappings = { git = "https://github.com/unipept/unipept-index.git" }
 thiserror = "1.0"

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -24,13 +24,14 @@ pub struct Index {
 
 impl Index {
     pub fn try_from_files(index_file: &str, proteins_file: &str) -> Result<Self, IndexError> {
-        let suffix_array =
-            load_index_file(index_file).map_err(|err| LoadIndexError::LoadSuffixArrayError(err.to_string()))?;
 
         let proteins = Proteins::try_from_database_file(proteins_file)
             .map_err(|_| LoadIndexError::LoadProteinsErrors(
                 LoadIndexError::FileNotFound(proteins_file.to_string()).to_string(),
             ))?;
+
+        let suffix_array =
+            load_index_file(index_file).map_err(|err| LoadIndexError::LoadSuffixArrayError(err.to_string()))?;
 
         let searcher = SparseSearcher::new(suffix_array, proteins);
 


### PR DESCRIPTION
During loading the datastructures, the protein text is compressed. During this compression, both the space for the text as the compressed text are allocated. After the compression, the space for the text is deallocated. By performing this compression before loading the SSA, we can reduce the peak memory of loading the data structures because the protein text is deallocated before the SSA is allocated. 