### PR TITLE
Replace uniprot call by extending the proteome store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "bitarray"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
+source = "git+https://github.com/unipept/unipept-index.git#46f9d269d9649239bb7db72901fa7510e76a41c4"
 
 [[package]]
 name = "bitflags"
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "fa-compression"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
+source = "git+https://github.com/unipept/unipept-index.git#46f9d269d9649239bb7db72901fa7510e76a41c4"
 
 [[package]]
 name = "fastrand"
@@ -1775,7 +1775,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "sa-compression"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#30121ce41057607fe153799ae471a5d769eef584"
+source = "git+https://github.com/unipept/unipept-index.git#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
  "sa-index",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "sa-index"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
+source = "git+https://github.com/unipept/unipept-index.git#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
  "clap",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "sa-mappings"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
+source = "git+https://github.com/unipept/unipept-index.git#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
  "bytelines",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "text-compression"
 version = "0.1.0"
-source = "git+https://github.com/unipept/unipept-index.git?branch=feature%2Fimprove-peak-memory#46f9d269d9649239bb7db72901fa7510e76a41c4"
+source = "git+https://github.com/unipept/unipept-index.git#46f9d269d9649239bb7db72901fa7510e76a41c4"
 dependencies = [
  "bitarray",
 ]

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -74,6 +74,7 @@ async fn handler(
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();
+    let proteome_store = datastore.reference_proteome_store();
 
     let filter_proteins: Box<dyn UniprotFilter> = match filter {
         Some(Filter::Taxa(taxa)) => {
@@ -84,7 +85,7 @@ async fn handler(
             }
         },
         Some(Filter::Proteomes(proteomes)) => {
-            Box::new(ProteomeFilter::new(proteomes).await.unwrap())
+            Box::new(ProteomeFilter::new(proteomes, proteome_store).await.unwrap())
         },
         Some(Filter::Proteins(proteins)) => {
             Box::new(ProteinFilter::new(proteins))

--- a/api/src/controllers/private_api/reference_proteomes.rs
+++ b/api/src/controllers/private_api/reference_proteomes.rs
@@ -28,7 +28,7 @@ async fn handler(
             .iter()
             .map(|proteome| proteome.trim())
             .filter_map(|proteome| {
-                datastore.reference_proteome_store().get(proteome).map(|(taxon_id, protein_count)| {
+                datastore.reference_proteome_store().get(proteome).map(|(taxon_id, protein_count, _)| {
                     let taxon_name = datastore
                         .taxon_store()
                         .get_name(*taxon_id).cloned() // Clone the &String to String

--- a/api/src/controllers/private_api/reference_proteomes_filter.rs
+++ b/api/src/controllers/private_api/reference_proteomes_filter.rs
@@ -55,7 +55,7 @@ async fn count_handler(
         Ok(ReferenceProteomeCountResult {
             count: proteome_store.mapper
                 .iter()
-                .filter(|(key, (taxon_id, _))| {
+                .filter(|(key, (taxon_id, _, _))| {
                     let taxon_name = get_taxon_name_by_id(datastore.taxon_store(), *taxon_id);
 
                     key.to_lowercase().contains(&filter.to_lowercase()) ||
@@ -79,9 +79,9 @@ async fn filter_handler(
 ) -> Result<Vec<String>, ()> {
     let proteome_store = datastore.reference_proteome_store();
 
-    let mut filtered_proteomes: Vec<(&String, &(u32, u32))> = proteome_store.mapper
+    let mut filtered_proteomes: Vec<(&String, &(u32, u32, String))> = proteome_store.mapper
         .iter()
-        .filter(|(key, (taxon_id, _))| {
+        .filter(|(key, (taxon_id, _, _))| {
             let taxon_name = get_taxon_name_by_id(datastore.taxon_store(), *taxon_id);
 
             key.to_lowercase().contains(&filter.to_lowercase()) ||
@@ -104,12 +104,12 @@ async fn filter_handler(
                 }
             };
             
-            filtered_proteomes.sort_by(|(_, &(a_taxon_id, _)), (_, &(b_taxon_id,_))| {
+            filtered_proteomes.sort_by(|(_, &(a_taxon_id, _, _)), (_, &(b_taxon_id,_, _))| {
                 sort_fn(a_taxon_id, b_taxon_id)
             });
         },
         "protein_count" => {
-            filtered_proteomes.sort_by(|(_, &(_, a_protein_count)), (_, &(_, b_protein_count))| {
+            filtered_proteomes.sort_by(|(_, &(_, a_protein_count, _)), (_, &(_, b_protein_count, _))| {
                 if sort_descending {
                     b_protein_count.cmp(&a_protein_count)
                 } else {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn start(index_location: &str, database_address: &str, port: u32) -> R
     let ec_numbers = format!("{}/datastore/ec_numbers.tsv", index_location);
     let go_terms = format!("{}/datastore/go_terms.tsv", index_location);
     let interpro_entries = format!("{}/datastore/interpro_entries.tsv", index_location);
-    let reference_proteomes = format!("{}/datastore/reference_proteomes.tsv", index_location);
+    let reference_proteomes = format!("{}/datastore/proteomes.tsv", index_location);
     let lineages = format!("{}/datastore/lineages.tsv", index_location);
     let taxons = format!("{}/datastore/taxons.tsv", index_location);
 

--- a/datastore/src/reference_proteome_store.rs
+++ b/datastore/src/reference_proteome_store.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use crate::errors::ReferenceProteomeStoreError;
 
-// taxon ID, protein count
-pub type ReferenceProteomeDescription = (u32, u32);
+// Taxon id, protein count, protein list
+pub type ReferenceProteomeDescription = (u32, u32, String);
 
 #[derive(Clone)]
 pub struct ReferenceProteomeStore {
@@ -20,10 +20,11 @@ impl ReferenceProteomeStore {
         for line in BufReader::new(file).lines() {
             let line = line?;
             let parts: Vec<&str> = line.split('\t').collect();
-            if parts.len() == 4 {
+            if parts.len() == 5 {
                 let taxon_id = parts[2].parse::<u32>().map_err(|_| ReferenceProteomeStoreError::ParseError(format!("Could not parse taxon ID: {}", parts[2])))?;
                 let protein_count = parts[3].parse::<u32>().map_err(|_| ReferenceProteomeStoreError::ParseError(format!("Could not parse protein count: {}", parts[3])))?;
-                mapper.insert(parts[1].to_string(), (taxon_id, protein_count));
+                let proteins = parts[4].to_string();
+                mapper.insert(parts[1].to_string(), (taxon_id, protein_count, proteins));
             }
         }
 
@@ -35,10 +36,14 @@ impl ReferenceProteomeStore {
     }
     
     pub fn get_taxon_id(&self, key: &str) -> Option<u32> {
-        self.mapper.get(key).map(|(taxon_id, _)| *taxon_id)
+        self.mapper.get(key).map(|(taxon_id, _, _)| *taxon_id)
     }
     
     pub fn get_protein_count(&self, key: &str) -> Option<u32> {
-        self.mapper.get(key).map(|(_, protein_count)| *protein_count)
+        self.mapper.get(key).map(|(_, protein_count, _)| *protein_count)
+    }
+
+    pub fn get_proteins(&self, key: &str) -> Option<Vec<&str>> {
+        self.mapper.get(key).map(|(_, _, proteins)| proteins.split(';').filter(|s| !s.is_empty()).collect())
     }
 }


### PR DESCRIPTION
This PR:
- Extends the ReferenceProteomeStore with a list of Proteins (as a string to save space)
- Updates the ProteomeFilter to remove the call to the uniprot API