### PR TITLE
Remove duplicate taxa

### DIFF
--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use axum::{extract::State, Json};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use index::{ProteinInfo, SearchResult};
 use crate::{
@@ -122,7 +123,7 @@ async fn handler(
                     }
                 }
 
-                let taxa: Vec<u32> = filtered_proteins.iter().map(|protein| protein.taxon).collect();
+                let taxa: Vec<u32> = filtered_proteins.iter().map(|protein| protein.taxon).unique().collect();
 
                 let lca = calculate_lca(
                     taxa.clone(),


### PR DESCRIPTION
Remove duplicate taxa before calculating the LCA. This will also remove the duplicate taxa when reporting all taxa.