### PR TITLE
Fix crash in pept2prot because of empty result sets

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,14 +13,21 @@
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
+  "forwardPorts": [80],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "apt update && apt install --yes libmysqlclient-dev && rm /var/lib/opensearch/nodes/0/node.lock /var/lib/opensearch/nodes/0/_state/write.lock"
+  "postCreateCommand": "apt update && apt install --yes libmysqlclient-dev && rm /var/lib/opensearch/nodes/0/node.lock /var/lib/opensearch/nodes/0/_state/write.lock",
 
   // Configure tool-specific properties.
   // "customizations": {},
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root"
+  // "remoteUser": "root",
+  "customizations": {
+    "jetbrains": {
+      "settings": {
+        "com.intellij:app:HttpConfigurable.use_proxy_pac": true
+      }
+    }
+  }
 }

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -65,6 +65,10 @@ async fn handler(
         .flat_map(|item| item.proteins.iter().map(|protein| protein.uniprot_accession.clone()))
         .collect();
 
+    if accession_numbers.is_empty() {
+        return Ok(vec![]);
+    }
+
     let accessions_map = get_accessions_map(connection, &accession_numbers)
         .await
         .map_err(|e| {


### PR DESCRIPTION
This PR provides a fix for an issue where the `pept2prot` API endpoint crashed if no peptide matches were found.