### PR TITLE
Fix/opensearch timeout

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0.120"
 serde_qs = "0.13.0"
 thiserror = "1.0"
 tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread", "macros"] }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["timeout"] }
 tower-http = { version = "0.5.2", features = ["cors", "trace", "limit", "normalize-path"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -56,7 +56,7 @@ async fn handler(
 
     // Step 6: Duplicate the results according to the original input
     let mut final_results = Vec::new();
-    for (unique_peptide, item) in unique_peptides.iter().zip(result.into_iter()) {
+    for (unique_peptide, item) in unique_peptides.iter().zip(result) {
         if let Some(count) = peptide_counts.get(unique_peptide) {
             let fa = calculate_fa(&item.proteins);
             let total_protein_count = *fa.counts.get("all").unwrap_or(&0);

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -35,7 +36,7 @@ pub struct EcInformation {
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra }: Parameters
-) -> Result<Vec<EcInformation>, ()> {
+) -> Result<Vec<EcInformation>, ApiError> {
     let input = sanitize_peptides(input);
 
     let mut peptide_counts: HashMap<String, usize> = HashMap::new();
@@ -49,7 +50,7 @@ async fn handler(
     let (unique_peptides, result) = tokio::task::spawn_blocking(move ||{
         let result = index.analyse(&unique_peptides, equate_il, false, None);
         (unique_peptides, result)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let ec_store = datastore.ec_store();
 
@@ -79,7 +80,7 @@ generate_handlers!(
     async fn json_handler(
         state => State<AppState>,
         params => Parameters
-    ) -> Result<Json<Vec<EcInformation>>, ()> {
+    ) -> Result<Json<Vec<EcInformation>>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -44,7 +44,10 @@ async fn handler(
     }
 
     let unique_peptides: Vec<String> = peptide_counts.keys().cloned().collect();
-    let result = index.analyse(&unique_peptides, equate_il, false, None);
+    let result = tokio::task::spawn_blocking({
+        let unique_peptides = unique_peptides.clone();
+        move || index.analyse(&unique_peptides, equate_il, false, None)
+    }).await.unwrap();
 
     let ec_store = datastore.ec_store();
 

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -44,10 +44,12 @@ async fn handler(
     }
 
     let unique_peptides: Vec<String> = peptide_counts.keys().cloned().collect();
-    let result = tokio::task::spawn_blocking({
-        let unique_peptides = unique_peptides.clone();
-        move || index.analyse(&unique_peptides, equate_il, false, None)
-    }).await.unwrap();
+    // Move unique_peptides into the blocking task and return it alongside the analysis result,
+    // so we can reuse the original vector without cloning
+    let (unique_peptides, result) = tokio::task::spawn_blocking(move ||{
+        let result = index.analyse(&unique_peptides, equate_il, false, None);
+        (unique_peptides, result)
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let ec_store = datastore.ec_store();
 

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -42,7 +42,9 @@ async fn handler(
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<FunctInformation>, ()> {
     let input = sanitize_peptides(input);
-    let result = index.analyse(&input, equate_il, false, None);
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, false, None)
+    }).await.unwrap();
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -44,7 +44,7 @@ async fn handler(
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -40,11 +41,11 @@ pub struct FunctInformation {
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
-) -> Result<Vec<FunctInformation>, ()> {
+) -> Result<Vec<FunctInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();
@@ -75,7 +76,7 @@ generate_handlers!(
     async fn json_handler(
         state => State<AppState>,
         params => Parameters
-    ) -> Result<Json<Vec<FunctInformation>>, ()> {
+    ) -> Result<Json<Vec<FunctInformation>>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -40,7 +40,7 @@ async fn handler(
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let go_store = datastore.go_store();
 

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -38,7 +38,9 @@ async fn handler(
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<GoInformation>, ()> {
     let input = sanitize_peptides(input);
-    let result = index.analyse(&input, equate_il, false, None);
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, false, None)
+    }).await.unwrap();
 
     let go_store = datastore.go_store();
 

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -36,11 +37,11 @@ pub struct GoInformation {
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
-) -> Result<Vec<GoInformation>, ()> {
+) -> Result<Vec<GoInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let go_store = datastore.go_store();
 
@@ -61,7 +62,7 @@ generate_handlers!(
     async fn json_handler(
         state => State<AppState>,
         params => Parameters
-    ) -> Result<Json<Vec<GoInformation>>, ()> {
+    ) -> Result<Json<Vec<GoInformation>>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -36,11 +37,11 @@ pub struct InterproInformation {
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains }: Parameters
-) -> Result<Vec<InterproInformation>, ()> {
+) -> Result<Vec<InterproInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let interpro_store = datastore.interpro_store();
 
@@ -61,7 +62,7 @@ generate_handlers!(
     async fn json_handler(
         state => State<AppState>,
         params => Parameters
-    ) -> Result<Json<Vec<InterproInformation>>, ()> {
+    ) -> Result<Json<Vec<InterproInformation>>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -40,7 +40,7 @@ async fn handler(
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let interpro_store = datastore.interpro_store();
 

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -38,7 +38,9 @@ async fn handler(
     Parameters { input, equate_il, extra, domains }: Parameters
 ) -> Result<Vec<InterproInformation>, ()> {
     let input = sanitize_peptides(input);
-    let result = index.analyse(&input, equate_il, false, None);
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, false, None)
+    }).await.unwrap();
 
     let interpro_store = datastore.interpro_store();
 

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -51,11 +52,11 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, names, validate_taxa }: Parameters,
     version: LineageVersion
-) -> Result<Vec<LcaInformation>, ()> {
+) -> Result<Vec<LcaInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();
@@ -97,7 +98,7 @@ generate_handlers! (
         state => State<AppState>,
         params => Parameters,
         version: LineageVersion
-    ) -> Result<Json<Vec<LcaInformation>>, ()> {
+    ) -> Result<Json<Vec<LcaInformation>>, ApiError> {
         Ok(Json(handler(state, params, version).await?))
     }
 );

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -53,7 +53,9 @@ async fn handler(
     version: LineageVersion
 ) -> Result<Vec<LcaInformation>, ()> {
     let input = sanitize_peptides(input);
-    let result = index.analyse(&input, equate_il, false, None);
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, false, None)
+    }).await.unwrap();
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -55,7 +55,7 @@ async fn handler(
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -58,7 +58,9 @@ async fn handler(
 
     let connection = database.get_conn();
 
-    let result = index.analyse(&input, equate_il, tryptic, Some(cutoff));
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, tryptic, Some(cutoff))
+    }).await.unwrap();
 
     let accession_numbers: HashSet<String> = result
         .iter()

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -60,7 +60,7 @@ async fn handler(
 
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, tryptic, Some(cutoff))
-    }).await.unwrap();
+    }).await?;
 
     let accession_numbers: HashSet<String> = result
         .iter()

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -68,7 +68,9 @@ async fn handler(
     version: LineageVersion
 ) -> Result<Vec<TaxaInformation>, ()> {
     let input = sanitize_peptides(input);
-    let result = index.analyse(&input, equate_il, tryptic, None);
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, tryptic, None)
+    }).await.unwrap();
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -70,7 +70,7 @@ async fn handler(
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, tryptic, None)
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -66,11 +67,11 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, names, tryptic, compact }: Parameters,
     version: LineageVersion
-) -> Result<Vec<TaxaInformation>, ()> {
+) -> Result<Vec<TaxaInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, tryptic, None)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();
@@ -127,7 +128,7 @@ generate_handlers! (
         state => State<AppState>,
         params => Parameters,
         version: LineageVersion
-    ) -> Result<Json<Vec<TaxaInformation>>, ()> {
+    ) -> Result<Json<Vec<TaxaInformation>>, ApiError> {
         Ok(Json(handler(state, params, version).await?))
     }
 );

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -65,7 +65,7 @@ async fn handler(
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::sanitize_peptides;
 
 #[derive(Deserialize)]
@@ -61,11 +62,11 @@ async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { input, equate_il, extra, domains, names, validate_taxa }: Parameters,
     version: LineageVersion
-) -> Result<Vec<PeptInformation>, ()> {
+) -> Result<Vec<PeptInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&input, equate_il, false, None)
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();
@@ -121,7 +122,7 @@ generate_handlers! (
         state => State<AppState>,
         params => Parameters,
         version: LineageVersion
-    ) -> Result<Json<Vec<PeptInformation>>, ()> {
+    ) -> Result<Json<Vec<PeptInformation>>, ApiError> {
         Ok(Json(handler(state, params, version).await?))
     }
 );

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -63,7 +63,9 @@ async fn handler(
     version: LineageVersion
 ) -> Result<Vec<PeptInformation>, ()> {
     let input = sanitize_peptides(input);
-    let result = index.analyse(&input, equate_il, false, None);
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&input, equate_il, false, None)
+    }).await.unwrap();
 
     let ec_store = datastore.ec_store();
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/protinfo.rs
+++ b/api/src/controllers/api/protinfo.rs
@@ -60,7 +60,7 @@ async fn handler(
     version: LineageVersion
 ) -> Result<Vec<ProtInformation>, ApiError> {
     let input = sanitize_proteins(input);
-    let input = HashSet::from_iter(input.into_iter());
+    let input = HashSet::from_iter(input);
 
     let connection = database.get_conn();
 

--- a/api/src/controllers/api/taxonomy.rs
+++ b/api/src/controllers/api/taxonomy.rs
@@ -173,7 +173,7 @@ async fn handler(
                         );
 
                         if let Some(values) = items {
-                            child_vector.extend(values.into_iter())
+                            child_vector.extend(values)
                         }
                     }
 

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -78,7 +78,7 @@ async fn handler(
     let peptides = sanitize_peptides(peptides);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&peptides, equate_il, tryptic, Some(cutoff))
-    }).await.unwrap();
+    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -76,7 +76,9 @@ async fn handler(
     peptides.dedup();
 
     let peptides = sanitize_peptides(peptides);
-    let result = index.analyse(&peptides, equate_il, tryptic, Some(cutoff));
+    let result = tokio::task::spawn_blocking(move || {
+        index.analyse(&peptides, equate_il, tryptic, Some(cutoff))
+    }).await.unwrap();
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     AppState
 };
+use crate::errors::ApiError;
 use crate::helpers::filters::crap_filter::CrapFilter;
 use crate::helpers::filters::empty_filter::EmptyFilter;
 use crate::helpers::filters::protein_filter::ProteinFilter;
@@ -67,7 +68,7 @@ pub struct Data {
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
     Parameters { mut peptides, equate_il, tryptic, cutoff, report_taxa, validate_taxa, blacklist_crap, filter }: Parameters
-) -> Result<Data, ()> {
+) -> Result<Data, ApiError> {
     if peptides.is_empty() {
         return Ok(Data { peptides: Vec::new() });
     }
@@ -78,7 +79,7 @@ async fn handler(
     let peptides = sanitize_peptides(peptides);
     let result = tokio::task::spawn_blocking(move || {
         index.analyse(&peptides, equate_il, tryptic, Some(cutoff))
-    }).await.map_err(|_| ())?; // This error could never happen, but just to be safe
+    }).await?;
 
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();
@@ -154,7 +155,7 @@ generate_handlers!(
     async fn json_handler(
         state=> State<AppState>,
         params => Parameters
-    ) -> Result<Json<Data>, ()> {
+    ) -> Result<Json<Data>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -25,6 +25,8 @@ pub enum ApiError {
     DatabaseError(#[from] database::DatabaseError),
     #[error("Unknown rank error")]
     UnknownRankError(String),
+    #[error("Join error")]
+    JoinError(#[from] tokio::task::JoinError),
     #[error("Not implemented: {0}")]
     NotImplementedError(String)
 }
@@ -39,6 +41,7 @@ impl IntoResponse for ApiError {
             ApiError::DatabaseError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error".to_string()),
             ApiError::UnknownRankError(message) => (StatusCode::BAD_REQUEST, message),
             ApiError::NotImplementedError(message) => (StatusCode::NOT_IMPLEMENTED, message),
+            ApiError::JoinError(join_error) => (StatusCode::INTERNAL_SERVER_ERROR, join_error.to_string()),
         };
 
         Response::builder().status(status).body(message.into()).unwrap()

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -41,7 +41,7 @@ impl IntoResponse for ApiError {
             ApiError::DatabaseError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error".to_string()),
             ApiError::UnknownRankError(message) => (StatusCode::BAD_REQUEST, message),
             ApiError::NotImplementedError(message) => (StatusCode::NOT_IMPLEMENTED, message),
-            ApiError::JoinError(join_error) => (StatusCode::INTERNAL_SERVER_ERROR, join_error.to_string()),
+            ApiError::JoinError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error".to_string()),
         };
 
         Response::builder().status(status).body(message.into()).unwrap()

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -1,9 +1,14 @@
+use std::time::Duration;
 use axum::{
-    extract::{DefaultBodyLimit},
+    BoxError,
+    error_handling::HandleErrorLayer,
+    extract::DefaultBodyLimit,
+    http::StatusCode,
     routing::get,
     Router
 };
 use tower::{ServiceBuilder};
+use tower::timeout::TimeoutLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::{
@@ -34,6 +39,10 @@ pub fn create_router(state: AppState) -> Router {
         .nest("/private_api", create_private_api_routes())
         .layer(
             ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(|_err: BoxError| async move {
+                    StatusCode::REQUEST_TIMEOUT
+                }))
+                .layer(TimeoutLayer::new(Duration::from_secs(60)))
                 // Set max request size to 50MiB (default is 2MiB)
                 .layer(DefaultBodyLimit::max(50 * 1024 * 1024))
                 .layer(RequestBodyLimitLayer::new(50 * 1024 * 1024))

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -28,7 +28,7 @@ use crate::{
     AppState
 };
 
-static REQUEST_TIMEOUT_DURATION: u64 = 150;
+const REQUEST_TIMEOUT_DURATION: u64 = 150;
 
 pub fn create_router(state: AppState) -> Router {
     init_tracing_subscriber();
@@ -41,8 +41,12 @@ pub fn create_router(state: AppState) -> Router {
         .nest("/private_api", create_private_api_routes())
         .layer(
             ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(|_err: BoxError| async move {
-                    StatusCode::REQUEST_TIMEOUT
+                .layer(HandleErrorLayer::new(|err: BoxError| async move {
+                    if err.is::<tower::timeout::error::Elapsed>() {
+                        StatusCode::REQUEST_TIMEOUT
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
                 }))
                 .layer(TimeoutLayer::new(Duration::from_secs(REQUEST_TIMEOUT_DURATION)))
                 // Set max request size to 50MiB (default is 2MiB)

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -28,6 +28,8 @@ use crate::{
     AppState
 };
 
+static REQUEST_TIMEOUT_DURATION: u64 = 150;
+
 pub fn create_router(state: AppState) -> Router {
     init_tracing_subscriber();
 
@@ -42,7 +44,7 @@ pub fn create_router(state: AppState) -> Router {
                 .layer(HandleErrorLayer::new(|_err: BoxError| async move {
                     StatusCode::REQUEST_TIMEOUT
                 }))
-                .layer(TimeoutLayer::new(Duration::from_secs(60)))
+                .layer(TimeoutLayer::new(Duration::from_secs(REQUEST_TIMEOUT_DURATION)))
                 // Set max request size to 50MiB (default is 2MiB)
                 .layer(DefaultBodyLimit::max(50 * 1024 * 1024))
                 .layer(RequestBodyLimitLayer::new(50 * 1024 * 1024))

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -12,6 +12,8 @@ use crate::DatabaseError::GeneralError;
 mod errors;
 mod models;
 
+static OPENSEARCH_TIMEOUT_DURATION: u64 = 120;
+
 pub struct Database {
     client: OpenSearch
 }
@@ -21,7 +23,7 @@ impl Database {
         let url = Url::parse(url)?;
         let conn_pool = SingleNodeConnectionPool::new(url);
         let transport = TransportBuilder::new(conn_pool)
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(OPENSEARCH_TIMEOUT_DURATION))
             .disable_proxy()
             .build()?;
         let client = OpenSearch::new(transport);

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -12,7 +12,7 @@ use crate::DatabaseError::GeneralError;
 mod errors;
 mod models;
 
-static OPENSEARCH_TIMEOUT_DURATION: u64 = 120;
+const OPENSEARCH_TIMEOUT_DURATION: u64 = 120;
 
 pub struct Database {
     client: OpenSearch

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap};
 use std::collections::HashSet;
+use std::time::Duration;
 pub use errors::DatabaseError;
 use models::UniprotEntry;
 use opensearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
@@ -19,7 +20,10 @@ impl Database {
     pub fn try_from_url(url: &str) -> Result<Self, DatabaseError> {
         let url = Url::parse(url)?;
         let conn_pool = SingleNodeConnectionPool::new(url);
-        let transport = TransportBuilder::new(conn_pool).disable_proxy().build()?;
+        let transport = TransportBuilder::new(conn_pool)
+            .timeout(Duration::from_secs(30))
+            .disable_proxy()
+            .build()?;
         let client = OpenSearch::new(transport);
         Ok(Self { client })
     }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -49,6 +49,10 @@ pub async fn get_accessions(
     client: &OpenSearch,
     accessions: &HashSet<String>,
 ) -> Result<Vec<UniprotEntry>, DatabaseError> {
+    if accessions.is_empty() {
+        return Ok(vec![]);
+    }
+
     let mut result: Vec<UniprotEntry> = Vec::new();
     
     let docs: Vec<_> = accessions


### PR DESCRIPTION
This pull request introduces two main improvements: it offloads potentially blocking computations to separate threads using `tokio::task::spawn_blocking`, and it adds request and OpenSearch timeouts to improve the reliability and responsiveness of the API. Previously the absence of timeouts, prevented the OpenSearch from resolving, thus holding on to all resources and blocking the API in the end.

Additionally, it includes a small optimization to avoid unnecessary database queries when no accessions are provided. This prevents the OpenSearch from taking more resources and throwing additional errors.

**Concurrency and blocking operations:**

* Updated all API handler functions to run the potentially blocking `index.analyse` calls inside `tokio::task::spawn_blocking`, preventing them from blocking the async runtime and improving overall server responsiveness.

**Timeouts and error handling:**

* Added a request timeout of 150 seconds to all API routes using `tower::timeout::TimeoutLayer` and returns a `REQUEST_TIMEOUT` status code on timeout.
* Set a 120 second timeout for OpenSearch database connections to prevent long-running or hanging queries. Error before the request itself can timeout.

**Dependency changes:**

* Updated the `tower` crate dependency to enable the `timeout` feature, required for the new timeout middleware.