### PR TITLE
Update endpoints and report whether protein matches cutoff was used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,6 +2284,8 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -29,6 +29,7 @@ pub struct Parameters {
 #[derive(Serialize)]
 pub struct EcInformation {
     peptide: String,
+    cutoff_used: bool,
     total_protein_count: usize,
     ec: Vec<EcNumber>
 }
@@ -60,12 +61,14 @@ async fn handler(
         if let Some(count) = peptide_counts.get(unique_peptide) {
             let fa = calculate_fa(&item.proteins);
             let total_protein_count = *fa.counts.get("all").unwrap_or(&0);
+            let cutoff_used = item.cutoff_used;
 
             for _ in 0..*count {
                 let ecs = ec_numbers_from_map(&fa.data, ec_store, extra);
 
                 final_results.push(EcInformation {
                     peptide: item.sequence.clone(),
+                    cutoff_used,
                     total_protein_count,
                     ec: ecs,
                 });

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -32,6 +32,7 @@ pub struct Parameters {
 #[derive(Serialize)]
 pub struct FunctInformation {
     peptide: String,
+    cutoff_used: bool,
     total_protein_count: usize,
     ec: Vec<EcNumber>,
     go: GoTerms,
@@ -63,6 +64,7 @@ async fn handler(
 
             FunctInformation {
                 peptide: item.sequence,
+                cutoff_used: item.cutoff_used,
                 total_protein_count,
                 ec: ecs,
                 go: gos,

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -30,6 +30,7 @@ pub struct Parameters {
 #[derive(Serialize)]
 pub struct GoInformation {
     peptide: String,
+    cutoff_used: bool,
     total_protein_count: usize,
     go: GoTerms
 }
@@ -53,7 +54,7 @@ async fn handler(
             let total_protein_count = *fa.counts.get("all").unwrap_or(&0);
             let gos = go_terms_from_map(&fa.data, go_store, extra, domains);
 
-            GoInformation { peptide: item.sequence, total_protein_count, go: gos }
+            GoInformation { peptide: item.sequence, cutoff_used: item.cutoff_used, total_protein_count, go: gos }
         })
         .collect())
 }

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -30,6 +30,7 @@ pub struct Parameters {
 #[derive(Serialize)]
 pub struct InterproInformation {
     peptide: String,
+    cutoff_used: bool,
     total_protein_count: usize,
     ipr: InterproEntries
 }
@@ -53,7 +54,7 @@ async fn handler(
             let total_protein_count = *fa.counts.get("all").unwrap_or(&0);
             let iprs = interpro_entries_from_map(&fa.data, interpro_store, extra, domains);
 
-            InterproInformation { peptide: item.sequence, total_protein_count, ipr: iprs }
+            InterproInformation { peptide: item.sequence, cutoff_used: item.cutoff_used, total_protein_count, ipr: iprs }
         })
         .collect())
 }

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -35,6 +35,7 @@ pub struct Parameters {
 #[derive(Serialize)]
 pub struct LcaInformation {
     peptide: String,
+    cutoff_used: bool,
     #[serde(flatten)]
     taxon: Taxon,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -81,6 +82,7 @@ async fn handler(
 
             Some(LcaInformation {
                 peptide: item.sequence,
+                cutoff_used: item.cutoff_used,
                 taxon: Taxon {
                     taxon_id: lca as u32,
                     taxon_name: name.to_string(),

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -32,6 +32,7 @@ pub struct Parameters {
 pub enum ProtInformation {
     Default {
         peptide: String,
+        cutoff_used: bool,
         uniprot_id: String,
         protein_name: String,
         taxon_id: u32,
@@ -39,6 +40,7 @@ pub enum ProtInformation {
     },
     Extra {
         peptide: String,
+        cutoff_used: bool,
         uniprot_id: String,
         protein_name: String,
         taxon_id: u32,
@@ -83,9 +85,10 @@ async fn handler(
     Ok(result
         .into_iter()
         .flat_map(|item| {
+            let cutoff_used = item.cutoff_used;
             item.proteins
                 .into_iter()
-                .filter_map(|protein| {
+                .filter_map(move |protein| {
                     let uniprot_entry = accessions_map.get(&protein.uniprot_accession)?;
 
                     if extra {
@@ -113,6 +116,7 @@ async fn handler(
 
                         Some(ProtInformation::Extra {
                             peptide: item.sequence.clone(),
+                            cutoff_used,
                             uniprot_id: protein.uniprot_accession.clone(),
                             protein_name: uniprot_entry.name.clone(),
                             taxon_id: uniprot_entry.taxon_id,
@@ -125,6 +129,7 @@ async fn handler(
                     } else {
                         Some(ProtInformation::Default {
                             peptide: item.sequence.clone(),
+                            cutoff_used,
                             uniprot_id: protein.uniprot_accession.clone(),
                             protein_name: uniprot_entry.name.clone(),
                             taxon_id: uniprot_entry.taxon_id,

--- a/api/src/controllers/api/pept2prot.rs
+++ b/api/src/controllers/api/pept2prot.rs
@@ -88,7 +88,7 @@ async fn handler(
             let cutoff_used = item.cutoff_used;
             item.proteins
                 .into_iter()
-                .filter_map(move |protein| {
+                .filter_map(|protein| {
                     let uniprot_entry = accessions_map.get(&protein.uniprot_accession)?;
 
                     if extra {

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -44,6 +44,7 @@ pub enum TaxaInformation {
 #[derive(Serialize)]
 pub struct DenseTaxaInformation {
     peptide: String,
+    cutoff_used: bool,
     #[serde(flatten)]
     taxon: Taxon,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -53,6 +54,7 @@ pub struct DenseTaxaInformation {
 #[derive(Serialize)]
 pub struct CompactTaxaInformation {
     peptide: String,
+    cutoff_used: bool,
     taxa: Vec<u32>
 }
 
@@ -88,6 +90,7 @@ async fn handler(
 
                 Some(TaxaInformation::Compact(CompactTaxaInformation {
                     peptide: item.sequence,
+                    cutoff_used: item.cutoff_used,
                     taxa: item_taxa,
                 }))
             })
@@ -98,6 +101,7 @@ async fn handler(
     Ok(result
         .into_iter()
         .flat_map(|item| {
+            let cutoff_used = item.cutoff_used;
             item.proteins.iter().map(|protein| protein.taxon).collect::<HashSet<u32>>().into_iter().filter_map(
                 move |taxon| {
                     let (name, rank, _) = taxon_store.get(taxon)?;
@@ -109,6 +113,7 @@ async fn handler(
 
                     Some(TaxaInformation::Dense(DenseTaxaInformation {
                         peptide: item.sequence.clone(),
+                        cutoff_used,
                         taxon: Taxon {
                             taxon_id: taxon,
                             taxon_name: name.to_string(),

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -41,6 +41,7 @@ pub struct Parameters {
 #[derive(Serialize)]
 pub struct PeptInformation {
     peptide: String,
+    cutoff_used: bool,
     total_protein_count: usize,
     ec: Vec<EcNumber>,
     go: GoTerms,
@@ -101,6 +102,7 @@ async fn handler(
 
             Some(PeptInformation {
                 peptide: item.sequence,
+                cutoff_used: item.cutoff_used,
                 total_protein_count,
                 ec: ecs,
                 go: gos,

--- a/api/src/controllers/mpa/pept2data.rs
+++ b/api/src/controllers/mpa/pept2data.rs
@@ -53,6 +53,7 @@ pub enum Filter {
 #[derive(Serialize)]
 pub struct DataItem {
     sequence: String,
+    cutoff_used: bool,
     lca: Option<u32>,
     lineage: Vec<Option<i32>>,
     fa: FunctionalAggregation,
@@ -111,7 +112,7 @@ async fn handler(
     Ok(Data {
         peptides: result
             .into_iter()
-            .filter_map(|SearchResult { proteins, sequence, .. }| {
+            .filter_map(|SearchResult { proteins, sequence, cutoff_used }| {
                 let filtered_proteins: Vec<ProteinInfo> = proteins
                     .into_iter()
                     .filter(|protein| filter_proteins.filter(protein))
@@ -141,6 +142,7 @@ async fn handler(
 
                 Some(DataItem {
                     sequence,
+                    cutoff_used,
                     lca: Some(lca as u32),
                     lineage,
                     fa: calculate_fa(&filtered_proteins),


### PR DESCRIPTION
We would like to update Unipept's Web application UI with a label that reports to the user whether the amount of protein matches for a peptide reached the max reportable amount of the API or not. Right now, this information is hidden from the user, but is nonetheless important.

See this issue for more information: https://github.com/unipept/unipept/issues/1839