### PR TITLE
Expose cutoff parameter for all endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,6 +2284,8 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/api/src/controllers/api/pept2ec.rs
+++ b/api/src/controllers/api/pept2ec.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_equate_il, default_extra},
+        api::{default_cutoff, default_equate_il, default_extra},
         generate_handlers
     },
     helpers::{
@@ -23,7 +23,9 @@ pub struct Parameters {
     #[serde(default = "default_equate_il")]
     equate_il: bool,
     #[serde(default = "default_extra")]
-    extra: bool
+    extra: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[derive(Serialize)]
@@ -35,7 +37,7 @@ pub struct EcInformation {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra }: Parameters
+    Parameters { input, equate_il, extra, cutoff }: Parameters
 ) -> Result<Vec<EcInformation>, ApiError> {
     let input = sanitize_peptides(input);
 
@@ -48,7 +50,7 @@ async fn handler(
     // Move unique_peptides into the blocking task and return it alongside the analysis result,
     // so we can reuse the original vector without cloning
     let (unique_peptides, result) = tokio::task::spawn_blocking(move ||{
-        let result = index.analyse(&unique_peptides, equate_il, false, None);
+        let result = index.analyse(&unique_peptides, equate_il, false, Some(cutoff));
         (unique_peptides, result)
     }).await?;
 

--- a/api/src/controllers/api/pept2funct.rs
+++ b/api/src/controllers/api/pept2funct.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_domains, default_equate_il, default_extra},
+        api::{default_cutoff, default_domains, default_equate_il, default_extra},
         generate_handlers
     },
     helpers::{
@@ -26,7 +26,9 @@ pub struct Parameters {
     #[serde(default = "default_extra")]
     extra: bool,
     #[serde(default = "default_domains")]
-    domains: bool
+    domains: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[derive(Serialize)]
@@ -40,11 +42,11 @@ pub struct FunctInformation {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra, domains }: Parameters
+    Parameters { input, equate_il, extra, domains, cutoff }: Parameters
 ) -> Result<Vec<FunctInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
-        index.analyse(&input, equate_il, false, None)
+        index.analyse(&input, equate_il, false, Some(cutoff))
     }).await?;
 
     let ec_store = datastore.ec_store();

--- a/api/src/controllers/api/pept2go.rs
+++ b/api/src/controllers/api/pept2go.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_domains, default_equate_il, default_extra},
+        api::{default_cutoff, default_domains, default_equate_il, default_extra},
         generate_handlers
     },
     helpers::{
@@ -24,7 +24,9 @@ pub struct Parameters {
     #[serde(default = "default_extra")]
     extra: bool,
     #[serde(default = "default_domains")]
-    domains: bool
+    domains: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[derive(Serialize)]
@@ -36,11 +38,11 @@ pub struct GoInformation {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra, domains }: Parameters
+    Parameters { input, equate_il, extra, domains, cutoff }: Parameters
 ) -> Result<Vec<GoInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
-        index.analyse(&input, equate_il, false, None)
+        index.analyse(&input, equate_il, false, Some(cutoff))
     }).await?;
 
     let go_store = datastore.go_store();

--- a/api/src/controllers/api/pept2interpro.rs
+++ b/api/src/controllers/api/pept2interpro.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_domains, default_equate_il, default_extra},
+        api::{default_cutoff, default_domains, default_equate_il, default_extra},
         generate_handlers
     },
     helpers::{
@@ -24,7 +24,9 @@ pub struct Parameters {
     #[serde(default = "default_extra")]
     extra: bool,
     #[serde(default = "default_domains")]
-    domains: bool
+    domains: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[derive(Serialize)]
@@ -36,11 +38,11 @@ pub struct InterproInformation {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra, domains }: Parameters
+    Parameters { input, equate_il, extra, domains, cutoff }: Parameters
 ) -> Result<Vec<InterproInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
-        index.analyse(&input, equate_il, false, None)
+        index.analyse(&input, equate_il, false, Some(cutoff))
     }).await?;
 
     let interpro_store = datastore.interpro_store();

--- a/api/src/controllers/api/pept2lca.rs
+++ b/api/src/controllers/api/pept2lca.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_equate_il, default_extra, default_names, default_validate_taxa},
+        api::{default_cutoff, default_equate_il, default_extra, default_names, default_validate_taxa},
         generate_handlers
     },
     helpers::{
@@ -29,7 +29,9 @@ pub struct Parameters {
     #[serde(default = "default_names")]
     names: bool,
     #[serde(default = "default_validate_taxa")]
-    validate_taxa: bool
+    validate_taxa: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[derive(Serialize)]
@@ -50,12 +52,12 @@ pub struct Taxon {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra, names, validate_taxa }: Parameters,
+    Parameters { input, equate_il, extra, names, validate_taxa, cutoff }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<LcaInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
-        index.analyse(&input, equate_il, false, None)
+        index.analyse(&input, equate_il, false, Some(cutoff))
     }).await?;
 
     let taxon_store = datastore.taxon_store();

--- a/api/src/controllers/api/pept2taxa.rs
+++ b/api/src/controllers/api/pept2taxa.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_equate_il, default_extra, default_names, default_compact, default_tryptic},
+        api::{default_cutoff, default_equate_il, default_extra, default_names, default_compact, default_tryptic},
         generate_handlers
     },
     helpers::lineage_helper::{
@@ -30,7 +30,9 @@ pub struct Parameters {
     #[serde(default = "default_tryptic")]
     tryptic: bool,
     #[serde(default = "default_compact")]
-    compact: bool
+    compact: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -65,12 +67,12 @@ pub struct Taxon {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra, names, tryptic, compact }: Parameters,
+    Parameters { input, equate_il, extra, names, tryptic, compact, cutoff }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<TaxaInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
-        index.analyse(&input, equate_il, tryptic, None)
+        index.analyse(&input, equate_il, tryptic, Some(cutoff))
     }).await?;
 
     let taxon_store = datastore.taxon_store();

--- a/api/src/controllers/api/peptinfo.rs
+++ b/api/src/controllers/api/peptinfo.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controllers::{
-        api::{default_domains, default_equate_il, default_extra, default_names, default_validate_taxa},
+        api::{default_cutoff, default_domains, default_equate_il, default_extra, default_names, default_validate_taxa},
         generate_handlers
     },
     helpers::{
@@ -35,7 +35,9 @@ pub struct Parameters {
     #[serde(default = "default_names")]
     names: bool,
     #[serde(default = "default_validate_taxa")]
-    validate_taxa: bool
+    validate_taxa: bool,
+    #[serde(default = "default_cutoff")]
+    cutoff: usize
 }
 
 #[derive(Serialize)]
@@ -60,12 +62,12 @@ pub struct Taxon {
 
 async fn handler(
     State(AppState { index, datastore, .. }): State<AppState>,
-    Parameters { input, equate_il, extra, domains, names, validate_taxa }: Parameters,
+    Parameters { input, equate_il, extra, domains, names, validate_taxa, cutoff }: Parameters,
     version: LineageVersion
 ) -> Result<Vec<PeptInformation>, ApiError> {
     let input = sanitize_peptides(input);
     let result = tokio::task::spawn_blocking(move || {
-        index.analyse(&input, equate_il, false, None)
+        index.analyse(&input, equate_il, false, Some(cutoff))
     }).await?;
 
     let ec_store = datastore.ec_store();


### PR DESCRIPTION
This PR adds support for explicitly setting the value of the cutoff parameter for all API endpoints that did not yet support this. The following endpoints have been updated with support for `cutoff`: `pept2ec`, `pept2funct`, `pept2go`, `pept2interpo`, `pept2lca`, `pept2taxa`, `peptinfo`.