### PR TITLE
Add option to report protein count when filtering by taxa in private_api

### DIFF
--- a/api/src/controllers/private_api/taxa.rs
+++ b/api/src/controllers/private_api/taxa.rs
@@ -1,16 +1,26 @@
+use std::collections::{HashMap, HashSet};
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
+use datastore::{LineageRank, LineageStore};
+use database::get_protein_counts_by_taxon_ids;
 
 use crate::{
     controllers::generate_handlers,
+    errors::ApiError,
     helpers::lineage_helper::{get_lineage_array, LineageVersion},
     AppState
 };
 
+fn default_report_protein_count() -> bool {
+    false
+}
+
 #[derive(Deserialize)]
 pub struct Parameters {
     #[serde(default)]
-    taxids: Vec<i32>
+    taxids: Vec<i32>,
+    #[serde(default = "default_report_protein_count")]
+    report_protein_count: bool
 }
 
 #[derive(Serialize)]
@@ -18,15 +28,91 @@ pub struct Taxon {
     id: u32,
     name: String,
     rank: String,
-    lineage: Vec<Option<i32>>
+    lineage: Vec<Option<i32>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    protein_count: Option<u32>
+}
+
+/// Resolves a taxon to the set of species/strain-level taxon IDs whose protein counts should be
+/// summed to produce the total protein count for this taxon.
+fn collect_protein_taxon_ids(
+    taxon_id: u32,
+    rank: &LineageRank,
+    lineage_store: &LineageStore
+) -> HashSet<u32> {
+    let rank_str = String::from(rank.clone());
+
+    match rank {
+        LineageRank::Strain => {
+            let mut ids = HashSet::new();
+            ids.insert(taxon_id);
+            ids
+        }
+        LineageRank::Species => {
+            let mut ids = HashSet::new();
+            ids.insert(taxon_id);
+            if let Some(lineages) = lineage_store.get_lineages_at_rank(&rank_str, taxon_id) {
+                for lin in lineages {
+                    if let Some(strain_id) = lin.strain {
+                        ids.insert(strain_id.unsigned_abs());
+                    }
+                }
+            }
+            ids
+        }
+        _ => {
+            let mut ids = HashSet::new();
+            if let Some(lineages) = lineage_store.get_lineages_at_rank(&rank_str, taxon_id) {
+                for lin in lineages {
+                    if let Some(species_id) = lin.species {
+                        ids.insert(species_id.unsigned_abs());
+                    }
+                    if let Some(strain_id) = lin.strain {
+                        ids.insert(strain_id.unsigned_abs());
+                    }
+                }
+            }
+            ids
+        }
+    }
 }
 
 async fn handler(
-    State(AppState { datastore, .. }): State<AppState>,
-    Parameters { taxids }: Parameters
-) -> Result<Vec<Taxon>, ()> {
+    State(AppState { datastore, database, .. }): State<AppState>,
+    Parameters { taxids, report_protein_count }: Parameters
+) -> Result<Vec<Taxon>, ApiError> {
     let taxon_store = datastore.taxon_store();
     let lineage_store = datastore.lineage_store();
+
+    let protein_counts: HashMap<u32, u32> = if report_protein_count {
+        let mut taxon_to_leaf_ids: HashMap<u32, HashSet<u32>> = HashMap::new();
+        let mut all_leaf_ids: HashSet<u32> = HashSet::new();
+
+        for &taxon_id in &taxids {
+            if taxon_id <= 0 { continue; }
+            let id = taxon_id as u32;
+            if let Some((_, rank, _)) = taxon_store.get(id) {
+                let leaf_ids = collect_protein_taxon_ids(id, rank, lineage_store);
+                all_leaf_ids.extend(&leaf_ids);
+                taxon_to_leaf_ids.insert(id, leaf_ids);
+            }
+        }
+
+        let all_leaf_ids_vec: Vec<i32> = all_leaf_ids.into_iter().map(|id| id as i32).collect();
+        let leaf_counts = get_protein_counts_by_taxon_ids(database.get_conn(), &all_leaf_ids_vec).await?;
+
+        taxon_to_leaf_ids
+            .into_iter()
+            .map(|(orig_id, leaf_ids)| {
+                let total: u32 = leaf_ids.iter()
+                    .map(|&lid| *leaf_counts.get(&lid).unwrap_or(&0))
+                    .sum();
+                (orig_id, total)
+            })
+            .collect()
+    } else {
+        HashMap::new()
+    };
 
     Ok(taxids
         .into_iter()
@@ -34,12 +120,18 @@ async fn handler(
         .filter_map(|taxon_id| {
             let (name, rank, _) = taxon_store.get(taxon_id as u32)?;
             let lineage = get_lineage_array(taxon_id as u32, LineageVersion::V2, lineage_store);
+            let protein_count = if report_protein_count {
+                Some(*protein_counts.get(&(taxon_id as u32)).unwrap_or(&0))
+            } else {
+                None
+            };
 
             Some(Taxon {
                 id: taxon_id as u32,
                 name: name.clone(),
                 rank: rank.clone().into(),
-                lineage
+                lineage,
+                protein_count
             })
         })
         .collect())
@@ -49,7 +141,7 @@ generate_handlers!(
     async fn json_handler(
         state => State<AppState>,
         params => Parameters
-    ) -> Result<Json<Vec<Taxon>>, ()> {
+    ) -> Result<Json<Vec<Taxon>>, ApiError> {
         Ok(Json(handler(state, params).await?))
     }
 );

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -217,6 +217,84 @@ pub async fn get_accessions_count_by_filter(
         .unwrap_or(0) as u32)
 }
 
+/// Counts proteins per taxon ID for a given list of taxon IDs.
+///
+/// # Arguments
+/// * `client` - OpenSearch client handle
+/// * `taxon_ids` - Slice of taxon IDs to count proteins for
+///
+/// # Returns
+/// * HashMap mapping each taxon ID to its protein count. Taxon IDs with no proteins are absent
+///   from the map (i.e., their count is implicitly 0).
+/// * `DatabaseError` if the query fails
+// OpenSearch enforces a hard limit on the number of terms in a single Terms Query.
+const OPENSEARCH_MAX_TERMS: usize = 65_000;
+
+pub async fn get_protein_counts_by_taxon_ids(
+    client: &OpenSearch,
+    taxon_ids: &[i32],
+) -> Result<HashMap<u32, u32>, DatabaseError> {
+    if taxon_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let taxon_ids_positive: Vec<i32> = taxon_ids.iter().copied().filter(|&id| id > 0).collect();
+
+    if taxon_ids_positive.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut merged: HashMap<u32, u32> = HashMap::new();
+
+    for chunk in taxon_ids_positive.chunks(OPENSEARCH_MAX_TERMS) {
+        let taxon_ids_json: Vec<serde_json::Value> = chunk.iter().map(|&id| json!(id)).collect();
+        let size = taxon_ids_json.len();
+
+        let body = json!({
+            "query": {
+                "terms": {
+                    "taxon_id": taxon_ids_json
+                }
+            },
+            "aggs": {
+                "proteins_per_taxon": {
+                    "terms": {
+                        "field": "taxon_id",
+                        "size": size
+                    }
+                }
+            },
+            "size": 0,
+            "track_total_hits": false
+        });
+
+        let response = client
+            .search(SearchParts::Index(&["uniprot_entries"]))
+            .body(body)
+            .send()
+            .await?;
+
+        if !response.status_code().is_success() {
+            return Err(GeneralError(response.text().await?));
+        }
+
+        let response_body: serde_json::Value = response.json().await?;
+
+        if let Some(buckets) = response_body["aggregations"]["proteins_per_taxon"]["buckets"].as_array() {
+            for bucket in buckets {
+                if let (Some(taxon_id), Some(count)) = (
+                    bucket["key"].as_u64().map(|v| v as u32),
+                    bucket["doc_count"].as_u64().map(|v| v as u32),
+                ) {
+                    *merged.entry(taxon_id).or_insert(0) += count;
+                }
+            }
+        }
+    }
+
+    Ok(merged)
+}
+
 /// Gets UniProt accession IDs from the database that match the given filter criteria
 ///
 /// # Arguments


### PR DESCRIPTION
This PR expands the `private_api/taxa` endpoint and adds a new parameter `report_protein_count` that will report the amount of proteins that are associated with the provided taxa. If a taxon is provided at a level that's higher than species or strain, the protein count is equal to the sum of the protein count of all descendant taxa.

Example:

**Request:**

```json
{
    "taxids": [4751],
    "report_protein_count": true
}
```

**Response:**

```json
[
    {
        "id": 4751,
        "name": "Fungi",
        "rank": "kingdom",
        "lineage": [
            2759,
            null,
            4751,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null
        ],
        "protein_count": 38050
    }
]
```