### PR TITLE
Implement new `private_api/taxa/unique_peptides` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitarray"
 version = "0.1.0"
 source = "git+https://github.com/unipept/unipept-index.git#2ff35f06ab808a44f1542ddf4ff86e94f6c70f91"
@@ -633,6 +648,17 @@ dependencies = [
 name = "fa-compression"
 version = "0.1.0"
 source = "git+https://github.com/unipept/unipept-index.git#2ff35f06ab808a44f1542ddf4ff86e94f6c70f91"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -2540,6 +2566,7 @@ dependencies = [
  "criterion",
  "database",
  "datastore",
+ "fancy-regex",
  "http",
  "http-body-util",
  "index",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -27,6 +27,7 @@ tower-layer = "0.3.2"
 tower-service = "0.3.2"
 itertools = "0.13.0"
 reqwest = { version = "0.12.8", features = [ "json" ] }
+fancy-regex = "0.14"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/api/src/controllers/private_api/mod.rs
+++ b/api/src/controllers/private_api/mod.rs
@@ -1,3 +1,4 @@
+pub mod unique_peptides;
 pub mod ecnumbers;
 pub mod goterms;
 pub mod interpros;

--- a/api/src/controllers/private_api/unique_peptides.rs
+++ b/api/src/controllers/private_api/unique_peptides.rs
@@ -1,0 +1,149 @@
+use axum::{extract::State, Json};
+use datastore::LineageRank;
+use fancy_regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    controllers::generate_handlers,
+    errors::ApiError,
+    AppState,
+};
+use database::get_proteins_for_taxon;
+
+fn default_cleavage_regex() -> String {
+    String::from("[KR](?!P)")
+}
+
+fn default_min_length() -> usize {
+    5
+}
+
+#[derive(Deserialize)]
+pub struct Parameters {
+    taxon_id: u32,
+    #[serde(default = "default_cleavage_regex")]
+    cleavage_regex: String,
+    #[serde(default = "default_min_length")]
+    min_length: usize,
+}
+
+#[derive(Serialize)]
+pub struct UniquePeptidesResult {
+    unique_peptides: Vec<String>,
+    total_peptides: usize,
+    total_unique_peptides: usize,
+}
+
+async fn handler(
+    State(AppState { index, datastore, database, .. }): State<AppState>,
+    Parameters { taxon_id, cleavage_regex, min_length }: Parameters,
+) -> Result<UniquePeptidesResult, ApiError> {
+    let re = Regex::new(&cleavage_regex)
+        .map_err(|e| ApiError::UnknownRankError(format!("Invalid cleavage_regex: {}", e)))?;
+
+    let taxon_info = datastore.taxon_store().get(taxon_id)
+        .ok_or_else(|| ApiError::UnknownRankError(format!("Taxon {} not found", taxon_id)))?;
+
+    let rank = &taxon_info.1;
+    if *rank != LineageRank::Species && *rank != LineageRank::Strain {
+        return Err(ApiError::UnknownRankError(format!(
+            "Taxon {} is at rank '{}', but must be at species or strain level",
+            taxon_id, rank
+        )));
+    }
+
+    let proteins = get_proteins_for_taxon(database.get_conn(), taxon_id).await?;
+
+    let mut peptides: Vec<String> = proteins.iter().flat_map(|protein| {
+        let sequence = &protein.protein;
+        let mut fragments = Vec::new();
+        let mut start = 0;
+        for m in re.find_iter(sequence).flatten() {
+            let end = m.end();
+            if end > start {
+                fragments.push(sequence[start..end].to_string());
+            }
+            start = end;
+        }
+        if start < sequence.len() {
+            fragments.push(sequence[start..].to_string());
+        }
+        fragments
+    }).collect();
+
+    peptides.retain(|p| p.len() >= min_length);
+    peptides.sort();
+    peptides.dedup();
+
+    let total_peptides = peptides.len();
+
+    let (peptides, results) = tokio::task::spawn_blocking(move || {
+        let results = index.analyse(&peptides, false, false, Some(10_000));
+        (peptides, results)
+    }).await?;
+
+    let unique_peptides: Vec<String> = peptides.into_iter()
+        .zip(results.into_iter())
+        .filter_map(|(peptide, result)| {
+            if result.cutoff_used || result.proteins.is_empty() {
+                return None;
+            }
+            if result.proteins.iter().all(|p| p.taxon == taxon_id) {
+                Some(peptide)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let total_unique_peptides = unique_peptides.len();
+
+    Ok(UniquePeptidesResult {
+        unique_peptides,
+        total_peptides,
+        total_unique_peptides,
+    })
+}
+
+generate_handlers!(
+    async fn json_handler(
+        state => State<AppState>,
+        params => Parameters
+    ) -> Result<Json<UniquePeptidesResult>, ApiError> {
+        Ok(Json(handler(state, params).await?))
+    }
+);
+
+#[cfg(test)]
+mod tests {
+    use fancy_regex::Regex;
+
+    fn cleave(sequence: &str, pattern: &str) -> Vec<String> {
+        let re = Regex::new(pattern).unwrap();
+        let mut fragments = Vec::new();
+        let mut start = 0;
+        for m in re.find_iter(sequence).flatten() {
+            let end = m.end();
+            if end > start {
+                fragments.push(sequence[start..end].to_string());
+            }
+            start = end;
+        }
+        if start < sequence.len() {
+            fragments.push(sequence[start..].to_string());
+        }
+        fragments
+    }
+
+    #[test]
+    fn tryptic_cleavage_splits_after_k_and_r_not_before_p() {
+        // K at pos 1 not followed by P → split after K; R at end of string → split after R
+        assert_eq!(cleave("MKVTLPGAR", "[KR](?!P)"), vec!["MK", "VTLPGAR"]);
+    }
+
+    #[test]
+    fn tryptic_cleavage_skips_k_before_p() {
+        // K at pos 3 is followed by P → no split; R at end of string → split after R
+        assert_eq!(cleave("ACTKPDEFR", "[KR](?!P)"), vec!["ACTKPDEFR"]);
+    }
+}

--- a/api/src/controllers/private_api/unique_peptides.rs
+++ b/api/src/controllers/private_api/unique_peptides.rs
@@ -34,6 +34,22 @@ pub struct UniquePeptidesResult {
     total_unique_peptides: usize,
 }
 
+fn cleave_sequence(sequence: &str, re: &Regex) -> Vec<String> {
+    let mut fragments = Vec::new();
+    let mut start = 0;
+    for m in re.find_iter(sequence).flatten() {
+        let end = m.end();
+        if end > start {
+            fragments.push(sequence[start..end].to_string());
+        }
+        start = end;
+    }
+    if start < sequence.len() {
+        fragments.push(sequence[start..].to_string());
+    }
+    fragments
+}
+
 async fn handler(
     State(AppState { index, datastore, database, .. }): State<AppState>,
     Parameters { taxon_id, cleavage_regex, min_length }: Parameters,
@@ -41,10 +57,9 @@ async fn handler(
     let re = Regex::new(&cleavage_regex)
         .map_err(|e| ApiError::UnknownRankError(format!("Invalid cleavage_regex: {}", e)))?;
 
-    let taxon_info = datastore.taxon_store().get(taxon_id)
+    let rank = datastore.taxon_store().get_rank(taxon_id)
         .ok_or_else(|| ApiError::UnknownRankError(format!("Taxon {} not found", taxon_id)))?;
 
-    let rank = &taxon_info.1;
     if *rank != LineageRank::Species && *rank != LineageRank::Strain {
         return Err(ApiError::UnknownRankError(format!(
             "Taxon {} is at rank '{}', but must be at species or strain level",
@@ -54,25 +69,12 @@ async fn handler(
 
     let proteins = get_proteins_for_taxon(database.get_conn(), taxon_id).await?;
 
-    let mut peptides: Vec<String> = proteins.iter().flat_map(|protein| {
-        let sequence = &protein.protein;
-        let mut fragments = Vec::new();
-        let mut start = 0;
-        for m in re.find_iter(sequence).flatten() {
-            let end = m.end();
-            if end > start {
-                fragments.push(sequence[start..end].to_string());
-            }
-            start = end;
-        }
-        if start < sequence.len() {
-            fragments.push(sequence[start..].to_string());
-        }
-        fragments
-    }).collect();
+    let mut peptides: Vec<String> = proteins.iter()
+        .flat_map(|protein| cleave_sequence(&protein.protein, &re))
+        .filter(|f| f.len() >= min_length)
+        .collect();
 
-    peptides.retain(|p| p.len() >= min_length);
-    peptides.sort();
+    peptides.sort_unstable();
     peptides.dedup();
 
     let total_peptides = peptides.len();
@@ -83,16 +85,12 @@ async fn handler(
     }).await?;
 
     let unique_peptides: Vec<String> = peptides.into_iter()
-        .zip(results.into_iter())
+        .zip(results)
         .filter_map(|(peptide, result)| {
-            if result.cutoff_used || result.proteins.is_empty() {
-                return None;
-            }
-            if result.proteins.iter().all(|p| p.taxon == taxon_id) {
-                Some(peptide)
-            } else {
-                None
-            }
+            (!result.cutoff_used
+                && !result.proteins.is_empty()
+                && result.proteins.iter().all(|p| p.taxon == taxon_id))
+            .then_some(peptide)
         })
         .collect();
 
@@ -116,34 +114,20 @@ generate_handlers!(
 
 #[cfg(test)]
 mod tests {
+    use super::cleave_sequence;
     use fancy_regex::Regex;
-
-    fn cleave(sequence: &str, pattern: &str) -> Vec<String> {
-        let re = Regex::new(pattern).unwrap();
-        let mut fragments = Vec::new();
-        let mut start = 0;
-        for m in re.find_iter(sequence).flatten() {
-            let end = m.end();
-            if end > start {
-                fragments.push(sequence[start..end].to_string());
-            }
-            start = end;
-        }
-        if start < sequence.len() {
-            fragments.push(sequence[start..].to_string());
-        }
-        fragments
-    }
 
     #[test]
     fn tryptic_cleavage_splits_after_k_and_r_not_before_p() {
+        let re = Regex::new("[KR](?!P)").unwrap();
         // K at pos 1 not followed by P → split after K; R at end of string → split after R
-        assert_eq!(cleave("MKVTLPGAR", "[KR](?!P)"), vec!["MK", "VTLPGAR"]);
+        assert_eq!(cleave_sequence("MKVTLPGAR", &re), vec!["MK", "VTLPGAR"]);
     }
 
     #[test]
     fn tryptic_cleavage_skips_k_before_p() {
+        let re = Regex::new("[KR](?!P)").unwrap();
         // K at pos 3 is followed by P → no split; R at end of string → split after R
-        assert_eq!(cleave("ACTKPDEFR", "[KR](?!P)"), vec!["ACTKPDEFR"]);
+        assert_eq!(cleave_sequence("ACTKPDEFR", &re), vec!["ACTKPDEFR"]);
     }
 }

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         datasets::sampledata,
         mpa::{pept2data},
-        private_api::{ecnumbers, goterms, interpros, metadata, proteins, proteins_filter, reference_proteomes, reference_proteomes_filter, taxa, taxa_filter}
+        private_api::{ecnumbers, goterms, interpros, metadata, proteins, proteins_filter, reference_proteomes, reference_proteomes_filter, taxa, taxa_filter, unique_peptides}
     },
     middleware::{
         cors::create_cors_layer,
@@ -146,6 +146,8 @@ fn create_private_api_routes() -> Router<AppState> {
         "/taxa/count",
         get(taxa_filter::get_json_count_handler).post(taxa_filter::post_json_count_handler),
         "/taxa/filter",
-        get(taxa_filter::get_json_filter_handler).post(taxa_filter::post_json_filter_handler)
+        get(taxa_filter::get_json_filter_handler).post(taxa_filter::post_json_filter_handler),
+        "/taxa/unique_peptides",
+        get(unique_peptides::get_json_handler).post(unique_peptides::post_json_handler)
     )
 }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -233,24 +233,18 @@ pub async fn get_proteins_for_taxon(
     taxon_id: u32,
 ) -> Result<Vec<UniprotEntry>, DatabaseError> {
     const PAGE_SIZE: usize = 1000;
-    let mut all_proteins: Vec<UniprotEntry> = Vec::new();
+    let mut all_proteins: Vec<UniprotEntry> = Vec::with_capacity(PAGE_SIZE);
     let mut search_after: Option<String> = None;
 
     loop {
-        let body = if let Some(ref last_accession) = search_after {
-            json!({
-                "query": { "term": { "taxon_id": taxon_id } },
-                "size": PAGE_SIZE,
-                "sort": [{ "uniprot_accession_number": "asc" }],
-                "search_after": [last_accession]
-            })
-        } else {
-            json!({
-                "query": { "term": { "taxon_id": taxon_id } },
-                "size": PAGE_SIZE,
-                "sort": [{ "uniprot_accession_number": "asc" }]
-            })
-        };
+        let mut body = json!({
+            "query": { "term": { "taxon_id": taxon_id } },
+            "size": PAGE_SIZE,
+            "sort": [{ "uniprot_accession_number": "asc" }]
+        });
+        if let Some(ref last_accession) = search_after {
+            body["search_after"] = json!([last_accession]);
+        }
 
         let response = client
             .search(SearchParts::Index(&["uniprot_entries"]))

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -217,6 +217,81 @@ pub async fn get_accessions_count_by_filter(
         .unwrap_or(0) as u32)
 }
 
+/// Retrieves all proteins from the database that belong to the given taxon ID
+///
+/// # Arguments
+/// * `client` - OpenSearch connection handle
+/// * `taxon_id` - NCBI taxon ID to retrieve proteins for
+///
+/// # Returns
+/// * Vector of `UniprotEntry` records for all proteins associated with the taxon
+/// * `DatabaseError` if the database operation fails
+///
+/// Uses `search_after` pagination to handle taxa with more than 10,000 proteins.
+pub async fn get_proteins_for_taxon(
+    client: &OpenSearch,
+    taxon_id: u32,
+) -> Result<Vec<UniprotEntry>, DatabaseError> {
+    const PAGE_SIZE: usize = 1000;
+    let mut all_proteins: Vec<UniprotEntry> = Vec::new();
+    let mut search_after: Option<String> = None;
+
+    loop {
+        let body = if let Some(ref last_accession) = search_after {
+            json!({
+                "query": { "term": { "taxon_id": taxon_id } },
+                "size": PAGE_SIZE,
+                "sort": [{ "uniprot_accession_number": "asc" }],
+                "search_after": [last_accession]
+            })
+        } else {
+            json!({
+                "query": { "term": { "taxon_id": taxon_id } },
+                "size": PAGE_SIZE,
+                "sort": [{ "uniprot_accession_number": "asc" }]
+            })
+        };
+
+        let response = client
+            .search(SearchParts::Index(&["uniprot_entries"]))
+            .body(body)
+            .send()
+            .await?;
+
+        if !response.status_code().is_success() {
+            return Err(GeneralError(response.text().await?));
+        }
+
+        let response_body: serde_json::Value = response.json().await?;
+
+        let hits = match response_body["hits"]["hits"].as_array() {
+            Some(h) => h,
+            None => break,
+        };
+
+        let hit_count = hits.len();
+
+        for hit in hits {
+            if let Ok(entry) = serde_json::from_value::<UniprotEntry>(hit["_source"].clone()) {
+                all_proteins.push(entry);
+            }
+        }
+
+        if hit_count < PAGE_SIZE {
+            break;
+        }
+
+        if let Some(last_hit) = hits.last() {
+            match last_hit["sort"][0].as_str() {
+                Some(sort_val) => search_after = Some(sort_val.to_string()),
+                None => break,
+            }
+        }
+    }
+
+    Ok(all_proteins)
+}
+
 /// Gets UniProt accession IDs from the database that match the given filter criteria
 ///
 /// # Arguments

--- a/datastore/src/taxon_store.rs
+++ b/datastore/src/taxon_store.rs
@@ -85,6 +85,10 @@ impl TaxonStore {
         self.mapper.get(&key).map(|(name, _, _)| name)
     }
 
+    pub fn get_rank(&self, key: u32) -> Option<&LineageRank> {
+        self.mapper.get(&key).map(|(_, rank, _)| rank)
+    }
+
     pub fn is_valid(&self, key: u32) -> bool {
         self.mapper.contains_key(&key) && self.mapper[&key].2
     }


### PR DESCRIPTION
## Add `/private_api/taxa/unique_peptides` endpoint

### Summary

  - Adds a new `GET`/`POST` endpoint at `/private_api/taxa/unique_peptides` (and `.json`) that computes taxon-unique peptides for a given strain or species.
  - Adds `get_proteins_for_taxon()` to the `database` crate: an exact `term`-query on `taxon_id` with `search_after` pagination to correctly handle taxa with more than 10,000 proteins.
  - Adds `fancy-regex` dependency to support lookahead assertions in user-supplied cleavage patterns (the standard `regex` crate does not support lookaheads).

### Endpoint contract
  
**Request parameters**

  | Parameter | Type | Required | Default | Description |
  |---|---|---|---|---|
  | `taxon_id` | `u32` | yes | — | NCBI taxon ID; must be at species or strain rank |
  | `cleavage_regex` | `string` | no | `[KR](?!P)` | Regex matching cleavage sites; split occurs after each match (standard tryptic convention) |
  | `min_length` | `usize` | no | `5` | Minimum peptide length in amino acids |

**Response**
  
  ```json
  {
    "unique_peptides": ["AAFEDLQSLQDK", "NLFVAKNLR"],
    "total_peptides": 4821,
    "total_unique_peptides": 312
  }
```
  
`total_peptides` is the count of deduplicated peptides after digestion and length filtering. `total_unique_peptides` equals `unique_peptides.length`.

**Error cases:**
  
  - 400 — invalid cleavage_regex
  - 400 — taxon_id not found in the taxon store
  - 400 — taxon_id is not at species or strain rank (message includes the actual rank)

**Algorithm:**
  
  1. Validate regex and taxon rank.
  2. Retrieve all proteins for the taxon from OpenSearch (get_proteins_for_taxon).
  3. Cleave each protein sequence at regex match boundaries (matched characters stay with the preceding fragment).
  4. Filter by min_length and deduplicate.
  5. Search the suffix array index for each candidate peptide (tryptic=false, equate_il=false).
  6. A peptide is unique if every matching protein in the index belongs to the target taxon and the result cutoff was not reached.
